### PR TITLE
fix: providerCtx not defined, should be ctx.run

### DIFF
--- a/docs/creators/javascript/docs/classes/executor_executor.TaskExecutor.md
+++ b/docs/creators/javascript/docs/classes/executor_executor.TaskExecutor.md
@@ -208,7 +208,7 @@ Map iterable data to worker function and return computed Task result as AsyncIte
 
 ```typescript
 const data = [1, 2, 3, 4, 5];
-const results = executor.map(data, (ctx, item) => providerCtx.ctx(`echo "${item}"`));
+const results = executor.map(data, (ctx, item) => ctx.run(`echo "${item}"`));
 for await (const result of results) console.log(result.stdout);
 ```
 

--- a/docs/creators/javascript/examples/simple.md
+++ b/docs/creators/javascript/examples/simple.md
@@ -50,7 +50,7 @@ The following example demonstrates how to use the `map` method:
 
 ```js
   const data = [1, 2, 3, 4, 5];
-  const results = executor.map(data, (ctx, item) => providerCtx.ctx(`echo "${item}"`));
+  const results = executor.map(data, (ctx, item) => ctx.run(`echo "${item}"`));
   for await (const result of results) console.log(result.stdout);
 ```
 


### PR DESCRIPTION
I ran into an error in the docs where `providerCtx.ctx` was not defined so I changed it to ctx.run based on other examples.