### PR TITLE
Fix centering with tags next to ArticleType icon

### DIFF
--- a/src/components/ArticleType.jsx
+++ b/src/components/ArticleType.jsx
@@ -7,7 +7,7 @@ export function ArticleType({ type, children }) {
   if (type.toLowerCase() === 'design') return null
 
   return (
-    <div className="mb-4 inline-flex items-center gap-x-2 rounded-2xl bg-lightbluedarker px-1.5 py-1 font-medium">
+    <div className="inline-flex items-center gap-x-2 rounded-2xl bg-lightbluedarker px-1.5 py-1 font-medium">
       {type.toLowerCase() === 'guide' ? (
         <TutorialIcon className="h-6 w-6 text-white" />
       ) : type.toLowerCase() === 'tutorial' ? (

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -239,20 +239,17 @@ export function Layout({
         )}
         <div className="min-w-0 max-w-5xl flex-auto px-4 py-16 lg:max-w-none lg:pl-8 lg:pr-0 xl:px-16">
           <article>
-            <div className="mb-1 flex items-center gap-x-4">
+            <div className="pb-4 flex items-center gap-x-4">
               {type && <ArticleType type={type} />}
-              {tags && (
-                <div className="flex gap-x-4 ">
-                  {tags.split(',').map((tag, index, array) => (
-                    <span
-                      className="text-sm text-normalgray dark:text-white/50"
-                      key={tag}
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              )}
+              {tags &&
+                tags.split(',').map((tag, index, array) => (
+                  <div
+                    className="block text-sm text-normalgray dark:text-white/50"
+                    key={tag}
+                  >
+                    {tag}
+                  </div>
+                ))}
             </div>
 
             <Prose>{children}</Prose>


### PR DESCRIPTION
# Previously:
<img width="352" alt="image" src="https://github.com/golemfactory/golem-docs/assets/33448819/37959a4a-e7d9-45ae-a52a-369be6626d1f">


# Now
<img width="300" alt="image" src="https://github.com/golemfactory/golem-docs/assets/33448819/fcabe5c1-3f1f-4d1b-85e2-1bf991626ff9">
