### PR TITLE
remove dashes from ids

### DIFF
--- a/src/markdoc/search.mjs
+++ b/src/markdoc/search.mjs
@@ -30,7 +30,7 @@ function extractSections(node, sections, isRoot = true) {
     let content = toString(node).trim()
     if (node.type === 'heading' && node.attributes.level <= 2) {
       let hash = node.attributes?.id ?? slugify(content)
-      sections.push([content, hash, []])
+      sections.push([content, hash.replace(/-/g, ''), []])
     } else {
       sections.at(-1)[2].push(content)
     }


### PR DESCRIPTION
Search "Installing" in the search bar and select the second result. Notice that the page isn't automatically scrolled to the id of the URL 

this PR solves this 

<img width="750" alt="image" src="https://github.com/golemfactory/golem-docs/assets/33448819/acc6f26c-65ee-4b3e-b3da-18b6b180dea2">
