### PR TITLE
Fix non-standard headings + mitigations for the future.

### DIFF
--- a/src/markdoc/nodes.js
+++ b/src/markdoc/nodes.js
@@ -8,8 +8,13 @@ function generateID(children, attributes) {
   if (attributes.id && typeof attributes.id === 'string') {
     return attributes.id
   }
+
   return children
-    .filter((child) => typeof child === 'string')
+    .map((child) =>
+      typeof child === 'object' && child.$$mdtype === 'Tag'
+        ? child.children.join(' ')
+        : child
+    )
     .join(' ')
     .replace(/[?]/g, '')
     .replace(/\s+/g, '-')

--- a/src/pages/docs/creators/dapps/creating-golem-dapps.md
+++ b/src/pages/docs/creators/dapps/creating-golem-dapps.md
@@ -80,7 +80,7 @@ The manifests are JSON files conforming to a specific schema, e.g.:
 }
 ```
 
-For more detailed information regarding the manifest files, the schema they use and their usage in Golem, please refer to: [Computation Payload Manifest](/docs/golem/payload-manifest/index).
+For more detailed information regarding the manifest files, the schema they use and their usage in Golem, please refer to: [Computation Payload Manifest](/docs/golem/payload-manifest).
 
 ### **Manifest signatures**
 
@@ -203,7 +203,7 @@ As mentioned earlier, in case of the VM runtime, the payload may be an image has
 
 If the payloads could be said to describe the “what” of your app, the nodes part describes the “how”. Each entry translates to a service that’s deployed to a provider. Each service must obviously specify the payload that it uses.
 
-#### `init`
+#### init
 
 Services need to specify any and all ExeScript commands that must be run in order for a given service to start. Those commands comprise the content of the `init` clause. Currently, only the `run` command is supported by the `dapp-runner`.
 
@@ -294,7 +294,7 @@ As an additional perk, using `dapp-manager` enables you to more conveniently int
 
 ### Connecting to services running on the providers
 
-As mentioned in the application descriptor section above ([`http_proxy` and `tcp_proxy`](/docs/creators/dapps/creating-golem-dapps#http_proxy-and-tcp_proxy)) by specifying a `http_proxy` or `tcp_proxy` in the application descriptor, you enable a given port within the node to be accessed using a local port on the requestor’s machine.
+As mentioned in the application descriptor section above ([`http_proxy` and `tcp_proxy`](/docs/creators/dapps/creating-golem-dapps#http-proxy-and-tcp-proxy)) by specifying a `http_proxy` or `tcp_proxy` in the application descriptor, you enable a given port within the node to be accessed using a local port on the requestor’s machine.
 
 #### Local HTTP proxy
 

--- a/src/pages/docs/creators/dapps/creating-golem-dapps.md
+++ b/src/pages/docs/creators/dapps/creating-golem-dapps.md
@@ -229,7 +229,7 @@ network: "default"
       - "192.168.0.4"
 ```
 
-#### this_sentence
+#### depends_on
 
 In addition to enumerating the services, you may wish to specify dependencies between them. If e.g. your back-end application assumes that it can connect to a database when it starts, you’ll need the database to be up and running already when you start the back-end. In such a case, your back-end component should specify a `depends_on` element pointing to the DB node. The startup of the back-end will then only be executed once the database is confirmed to have started successfully.
 

--- a/src/pages/docs/creators/dapps/creating-golem-dapps.md
+++ b/src/pages/docs/creators/dapps/creating-golem-dapps.md
@@ -47,47 +47,40 @@ The manifests are JSON files conforming to a specific schema, e.g.:
 
 ```json
 {
-    "version": "0.1.0",
-    "createdAt": "2022-12-01T00:00:00.000000Z",
-    "expiresAt": "2100-01-01T00:00:00.000000Z",
-    "payload": [
-        {
-          "platform": {
-            "arch": "x86_64",
-            "os": "linux"
-          },
-          "urls": [
-            "http://girepo.dev.golem.network:8000/docker-gas_scanner_backend_image-latest-91c471517a.gvmi"
-          ],
-          "hash": "sha3:05270a8a938ff5f5e30b0e61bc983a8c3e286c5cd414a32e1a077657"
-        }
-      ],
-      "compManifest": {
-      "version": "0.1.0",
-      "script": {
-        "commands": [
-          "run .*"
-        ],
-        "match": "regex"
+  "version": "0.1.0",
+  "createdAt": "2022-12-01T00:00:00.000000Z",
+  "expiresAt": "2100-01-01T00:00:00.000000Z",
+  "payload": [
+    {
+      "platform": {
+        "arch": "x86_64",
+        "os": "linux"
       },
-      "net": {
-        "inet": {
-          "out": {
-            "protocols": [
-              "http"
-            ],
-            "urls": [
-                "http://bor.golem.network"
-            ]
-          }
+      "urls": [
+        "http://girepo.dev.golem.network:8000/docker-gas_scanner_backend_image-latest-91c471517a.gvmi"
+      ],
+      "hash": "sha3:05270a8a938ff5f5e30b0e61bc983a8c3e286c5cd414a32e1a077657"
+    }
+  ],
+  "compManifest": {
+    "version": "0.1.0",
+    "script": {
+      "commands": ["run .*"],
+      "match": "regex"
+    },
+    "net": {
+      "inet": {
+        "out": {
+          "protocols": ["http"],
+          "urls": ["http://bor.golem.network"]
         }
       }
     }
   }
+}
 ```
 
 For more detailed information regarding the manifest files, the schema they use and their usage in Golem, please refer to: [Computation Payload Manifest](/docs/golem/payload-manifest/index).
-
 
 ### **Manifest signatures**
 
@@ -218,13 +211,13 @@ Example initialization ExeScript:
 
 ```yaml
 init:
-      - run:
-          args: ["/bin/chmod", "a+x", "/"]
-      - run:
-          args: ["/bin/bash", "-c", "/bin/run_web.sh 192.168.0.3 &"]
+  - run:
+      args: ['/bin/chmod', 'a+x', '/']
+  - run:
+      args: ['/bin/bash', '-c', '/bin/run_web.sh 192.168.0.3 &']
 ```
 
-#### `network` and `ip`
+#### network and ip
 
 Most of the applications consisting of more than one node will likely require the individual nodes to be connected to each other. That’s what the `network` and `ip` elements are for. As expected, they specify, respectively, which of the defined networks a given node should be part of and what IP address should be assigned to the node within the network.
 
@@ -236,7 +229,7 @@ network: "default"
       - "192.168.0.4"
 ```
 
-#### `depends_on`
+#### this_sentence
 
 In addition to enumerating the services, you may wish to specify dependencies between them. If e.g. your back-end application assumes that it can connect to a database when it starts, you’ll need the database to be up and running already when you start the back-end. In such a case, your back-end component should specify a `depends_on` element pointing to the DB node. The startup of the back-end will then only be executed once the database is confirmed to have started successfully.
 
@@ -244,10 +237,10 @@ Example:
 
 ```yaml
 depends_on:
-      - "api"
+  - 'api'
 ```
 
-#### `http_proxy` and `tcp_proxy`
+#### http_proxy and tcp_proxy
 
 Those two components specify the two currently supported ways of exposing a service within your app to the outside world. Both of them open a local port on the requestor machine and route the traffic to your application through that open port.
 
@@ -255,8 +248,8 @@ Example:
 
 ```yaml
 http_proxy:
-      ports:
-        - "80"
+  ports:
+    - '80'
 ```
 
 You can specify just one port or a colon-separated mapping. If a single number is specified, the given remote port will be mapped to an automatically-chosen local port. On the other hand, specifying another number after a colon will attempt to map the remote port to this specific local port but will fail if it is already taken.
@@ -264,7 +257,7 @@ You can specify just one port or a colon-separated mapping. If a single number i
 Once a service is launched and `dapp-runner` succeeds in starting a local proxy, it will emit the following message to the `data` stream:
 
 ```json
-{"cache": {"local_proxy_address": "http://localhost:8080"}}
+{ "cache": { "local_proxy_address": "http://localhost:8080" } }
 ```
 
 You should be able to access your service using that published URL.
@@ -301,7 +294,7 @@ As an additional perk, using `dapp-manager` enables you to more conveniently int
 
 ### Connecting to services running on the providers
 
-As mentioned in the application descriptor section above ([`http_proxy` and `tcp_proxy`](/docs/creators/dapps/creating-golem-dapps#http\_proxy-and-tcp\_proxy)) by specifying a `http_proxy` or `tcp_proxy` in the application descriptor, you enable a given port within the node to be accessed using a local port on the requestor’s machine.
+As mentioned in the application descriptor section above ([`http_proxy` and `tcp_proxy`](/docs/creators/dapps/creating-golem-dapps#http_proxy-and-tcp_proxy)) by specifying a `http_proxy` or `tcp_proxy` in the application descriptor, you enable a given port within the node to be accessed using a local port on the requestor’s machine.
 
 #### Local HTTP proxy
 
@@ -315,13 +308,13 @@ nodes:
     #
     http_proxy:
       ports:
-        - "80"
+        - '80'
 ```
 
 This enables an automatically-chosen local port to be mapped to a remote port. Once the service is completely initialized on the remote node, dapp-runner emits a data message with a location of the mapped port:
 
 ```json
-{"backend": {"local_proxy_address": "http://localhost:8081"}}
+{ "backend": { "local_proxy_address": "http://localhost:8081" } }
 ```
 
 You can then use your browser or any other HTTP-based tool to access the service. Choosing the HTTP proxy has two benefits as compared with the generic TCP proxy. First, it causes requests and responses to be logged by the `dapp-runner` and allows for easier debugging in case of issues. Secondly, and possibly more importantly, it allows the service exposed in this way to be available when the application is deployed on Golem's Portal.
@@ -338,13 +331,13 @@ nodes:
     #
     tcp_proxy:
       ports:
-        - "27017"
+        - '27017'
 ```
 
 After the given node has finished its startup, dapp-runner emits a data message giving the location of the mapped port:
 
 ```json
-{"mongo": {"local_tcp_proxy_address": "localhost:8080"}}
+{ "mongo": { "local_tcp_proxy_address": "localhost:8080" } }
 ```
 
 Using a generic TCP proxy enables connections to all kinds of TCP-based services. You can use it to connect directly to a database, an SSH server, or other kinds of services. This may be useful for debugging purposes or maybe because running a database on a provider that you connect to from the outside is exactly what you want to use Golem Deploy framework for.

--- a/src/pages/docs/creators/dapps/index.md
+++ b/src/pages/docs/creators/dapps/index.md
@@ -6,8 +6,8 @@ title: Deploying long-running, decentralized services on Golem using no-code too
 # Decentralized applications on Golem
 
 {% alert level="info" %}
-    Looking for a QuickStart?
-    
+Looking for a QuickStart?
+
     [See how easy it is to run an application on Golem](/docs/creators/dapps/run-a-dapp)
 
 {% /alert %}
@@ -28,30 +28,27 @@ Please be aware that the dApps on Golem project is still in early access and sho
 
 {% /alert %}
 
-
-
-
 ## Available experiments
 
 While working with dApps, we created a few applications on top of it, which served us both as a testing ground and as a way to validate our approach. On the other hand, they were also designed to give you, first, a good starting point, and later, a reference, when developing your own, similar apps.
 
-### ToDo List Application [\[GitHub\]](https://github.com/golemfactory/dapp-experiments/tree/main/01\_todo\_app)
+### ToDo List Application
 
 ![ToDo List App](https://user-images.githubusercontent.com/33448819/223681578-03193431-ed28-46e7-9faf-00bc0ea00613.png)
 
-This application showcases utilizing the Golem Network to host a 3-layer application (**React** + **Flask** + **RQLite**)
+This [application](https://github.com/golemfactory/dapp-experiments/tree/main/01_todo_app) showcases utilizing the Golem Network to host a 3-layer application (**React** + **Flask** + **RQLite**)
 
-### Weather Stats Application [\[GitHub\]](https://github.com/golemfactory/dapp-experiments/tree/main/02\_weather\_stats)
+### Weather Stats Application
 
 ![Weather Stats App](/weather-stats.png)
 
-This application presents usage of the Golem Network with access to external services (not hosted on Golem) taking advantage of the outbound network connections.
+This [application](https://github.com/golemfactory/dapp-experiments/tree/main/02_weather_stats) presents usage of the Golem Network with access to external services (not hosted on Golem) taking advantage of the outbound network connections.
 
 ## Components
 
 ### Golem Services
 
-Golem __Service model__ describes a way to run specific Golem payloads and defines operations that need to be applied on state transitions throughout their lifetime.
+Golem **Service model** describes a way to run specific Golem payloads and defines operations that need to be applied on state transitions throughout their lifetime.
 
 The payloads are the definitions of activities that a requestor wishes to be executed on Golem along with a complete set of parameters needed to initialize those activities. Those parameters can specify, e.g. what runtime and which container image to use or what the CPU or memory specifications are required by the payload.
 
@@ -72,7 +69,6 @@ The model and the schema used are documented in:
 Dapp-runner is an initial, reference implementation that allows applications defined as Golem dApps to be deployed and maintained on the Golem Network. It takes one or more application descriptors expressed as YAML files, constructs the desired dApp model for such an application, and executes all operations needed for the services constituting the app to be successfully deployed on Golem.
 
 [See dapp-runner on GitHub](https://github.com/golemfactory/dapp-runner/)
-
 
 ### Dapp-manager
 

--- a/src/pages/docs/golem/payload-manifest/index.md
+++ b/src/pages/docs/golem/payload-manifest/index.md
@@ -2,18 +2,19 @@
 title: Payload Manifest Introduction
 description: Computation Payload Manifest description, its schema, and configuration guide
 ---
+
 # Computation Payload Manifest
 
 _Computation Payload Manifest_ allows a [requestor](/docs/golem/overview/requestor) to define an application package _Payload_ and allows to set constraints on the computations performed on a [provider](/docs/golem/overview/provider) node.
 
-A manifest can be configured in yapapi. 
+A manifest can be configured in yapapi.
 
 [//]: <> ( removed link to yapapi in the sentence above )
 
 The provider node operator controls what computations can be performed by:
 
-  - [Importing certificates] used to sign app authors' certificates into the provider's [keystore](/docs/providers/yagna-cli-reference#keystore) (which allows the provider agent to verify _manifest_ signatures)
-  - Adding domain patterns to Provider's [domain whitelist](/docs/providers/yagna-cli-reference#domain-whitelist) (which makes the manifest [signature] optional).
+- [Importing certificates] used to sign app authors' certificates into the provider's [keystore](/docs/providers/yagna-cli-reference#keystore) (which allows the provider agent to verify _manifest_ signatures)
+- Adding domain patterns to Provider's [domain whitelist](/docs/providers/yagna-cli-reference#domain-whitelist) (which makes the manifest [signature] optional).
 
 ## Configuration
 
@@ -22,7 +23,6 @@ The manifest can be configured as a [yapapi.payload.vm.manifest](https://yapapi.
 ## Manifest schema
 
 _Computation Payload Manifest_ must follow a specific [JSON Schema](https://github.com/golemfactory/yagna-docs/blob/master/requestor-tutorials/vm-runtime/computation-payload-manifest.schema.json) ([Documentation](/docs/golem/payload-manifest/computation-payload-manifest.schema))
-
 
 ### Schema verification
 
@@ -36,7 +36,7 @@ jsonschema --instance manifest.json computation-payload-manifest.schema.json
 
 ### Payload object
 
-_Computation Payload Manifest_ **must** contain at least one _Payload_ object. 
+_Computation Payload Manifest_ **must** contain at least one _Payload_ object.
 
 _Payload_ definition allows to define [GVMI images](/docs/creators/javascript/guides/golem-images) used by Application and supported architecture.
 
@@ -64,85 +64,84 @@ Simple _Computation Payload Manifest_ with _Payload_ definition:
 
 ### Computation Manifest object
 
-_Computation Payload Manifest_ **can** contain _Computation Manifests_ object. 
+_Computation Payload Manifest_ **can** contain _Computation Manifests_ object.
 
-With a Computation Manifest object, [requestor](/docs/golem/overview/requestor) constrains themself to a certain set of allowed actions, to be negotiated with and approved by a [provider](/docs/golem/overview/provider). 
+With a Computation Manifest object, [requestor](/docs/golem/overview/requestor) constrains themself to a certain set of allowed actions, to be negotiated with and approved by a [provider](/docs/golem/overview/provider).
 
 Requestors' actions will be verified against the _Manifest_ during computation.
 
 Supported _Computation Manifest_ constraints:
 
-  - #### `compManifest.script`
+- #### compManifest.script
 
-    Defines a set of allowed ExeScript commands and applies constraints to their arguments.
+  Defines a set of allowed ExeScript commands and applies constraints to their arguments.
 
-    - #### `compManifest.script.commands` : List[Script]
-  
-      Specifies a curated list of commands in a form of:
+  - #### compManifest.script.commands
 
-      - UTF-8 encoded JSON strings
+    `compManifest.script.commands : List[Script]` specifies a curated list of commands in a form of:
 
-        Command context (e.g. env) or argument matching mode needs to be specified for a command.
+    - UTF-8 encoded JSON strings
 
-        Example: 
-        
-        ```json
-        [
-          "{
-            \"run\": { 
-              \"args\": \"/bin/date -R\", 
-              \"env\": { 
-                \"MYVAR\": \"42\", 
-                \"match\": \"strict\" 
-              }
+      Command context (e.g. env) or argument matching mode needs to be specified for a command.
+
+      Example:
+
+      ```json
+      [
+        "{
+          \"run\": {
+            \"args\": \"/bin/date -R\",
+            \"env\": {
+              \"MYVAR\": \"42\",
+              \"match\": \"strict\"
             }
-          }"
-        ]
+          }
+        }"
+      ]
 
-      - UTF-8 encoded strings
+      ```
 
-        No command context or matching mode needs to be specified.
+    - UTF-8 encoded strings
 
-        Example: 
-        
-        ```json
-        [
-          "run /bin/cat /etc/motd", 
-          "run /bin/date -R"
-        ]
-        ```
+      No command context or matching mode needs to be specified.
 
-      - Mix of both
+      Example:
 
-      Commands `deploy`, `start` and `terminate` are always allowed. These values become the default if no `compManifest.script.commands` property has been set, but the `compManifest` object is present.
+      ```json
+      ["run /bin/cat /etc/motd", "run /bin/date -R"]
+      ```
 
-    - #### `compManifest.script.match` : String
-    
-      Selects a default way of comparing command arguments stated in the manifest and the ones received in the ExeScript, unless stated otherwise in a command JSON object.
+    - Mix of both
 
-      The `match` property could be one of:
+    Commands `deploy`, `start` and `terminate` are always allowed. These values become the default if no `compManifest.script.commands` property has been set, but the `compManifest` object is present.
 
-        - `strict`: byte-to-byte argument equality (default)
+  - #### compManifest.script.match
 
-        - `regex`: treat arguments as regular expressions
+    `compManifest.script.match : String` selects a default way of comparing command arguments stated in the manifest and the ones received in the ExeScript, unless stated otherwise in a command JSON object.
 
-          Syntax: Perl-compatible regular expressions (UTF-8 Unicode mode), w/o the support for a look around and backreferences (among others).
-  
-  - #### `compManifest.net` : Object
+    The `match` property could be one of:
 
-    Applies constraints to networking.
+    - `strict`: byte-to-byte argument equality (default)
 
-    - #### `compManifest.net.inet.out` : Object
+    - `regex`: treat arguments as regular expressions
 
-      Outgoing requests to the public Internet network constraints.
+      Syntax: Perl-compatible regular expressions (UTF-8 Unicode mode), w/o the support for a look around and backreferences (among others).
 
-      - #### `compManifest.net.inet.out.protocols` : List[String]
+- #### compManifest.net
 
-        List of allowed outbound protocols. Currently fixed at ["http", "https"].
+  `compManifest.net : Object` applies constraints to networking.
 
-      - #### `compManifest.net.inet.out.urls` : List[String]
+  - #### compManifest.net.inet.out
 
-        List of allowed external URLs that outbound requests can be sent to. E.g. ["https://api.some-public-service.com", "https://some-other-service.com/api/resource"]
+    `compManifest.net.inet.out : Object` outgoing requests to the public Internet network constraints.
+
+    - #### compManifest.net.inet.out.protocols
+
+      `compManifest.net.inet.out.protocols : List[String]` list of allowed outbound protocols. Currently fixed at ["http", "https"].
+
+    - #### compManifest.net.inet.out.urls
+
+      `compManifest.net.inet.out.urls : List[String]` list of allowed external URLs that outbound requests can be sent to. E.g. ["https://api.some-public-service.com", "https://some-other-service.com/api/resource"]
 
 ### Example of _Computation Payload Manifest_ with _Computation Manifest_ definition:
 
@@ -162,10 +161,7 @@ Supported _Computation Manifest_ constraints:
   "compManifest": {
     "version": "0.1.0",
     "script": {
-      "commands": [
-        "run curl.*",
-        "transfer .*/output.txt"
-      ],
+      "commands": ["run curl.*", "transfer .*/output.txt"],
       "match": "regex"
     },
     "net": {
@@ -265,15 +261,11 @@ basicConstraints = CA:true
 
 Then generate _App author's certificate_ Signing Request (use same `organizationName`):
 
-
 `openssl req -new -newkey rsa:2048 -days 360 -sha256 -keyout author.key.pem -out author.csr.pem -config openssl.conf`
-
 
 Finally, generate _App author's certificate_ using CSR and CA certificate:
 
-
 `openssl x509 -req -in author.csr.pem -CA ca.crt.pem -CAkey ca.key.pem -CAcreateserial -out author.crt.pem`
-
 
 #### 3. Importing application author's certificates
 

--- a/verify-headings.js
+++ b/verify-headings.js
@@ -1,0 +1,31 @@
+const fs = require('fs')
+const marked = require('marked')
+const glob = require('glob')
+
+let isValid = true
+
+glob('src/pages/docs/**/*.md', (err, files) => {
+  if (err) throw err
+
+  files.forEach((file) => {
+    const data = fs.readFileSync(file, 'utf8')
+    const renderer = new marked.Renderer()
+
+    renderer.heading = (text) => {
+      if (file.startsWith('src/pages/docs/golem-js/reference/')) return
+
+      if (/(\*\*__)|([^\\]\*)|(`+)|(\[+)|(\]+)/g.test(text.trim())) {
+        console.error(
+          `Invalid heading in file ${file}: ${text} contains markdown syntax \n`
+        )
+        isValid = false
+      }
+    }
+
+    marked.parse(data, { renderer })
+  })
+})
+
+process.on('exit', () => {
+  if (isValid) console.log('All headings are valid')
+})


### PR DESCRIPTION
This PR fixes the articles that had markdown syntax inside the headings, which resulted in id's not being generated for the headings and caused articles to look funky. This has been addressed and now we also have a verify-headings.js script which can find some of these for us in the future.