### PR TITLE
Dont use fail-fast on branch failure

### DIFF
--- a/.github/workflows/build-reference-and-issue-pr.yml
+++ b/.github/workflows/build-reference-and-issue-pr.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         branch: ['master', 'beta', 'alpha']
     runs-on: ubuntu-latest
@@ -15,9 +16,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ matrix.branch }}
-      - run: npm ci
+      - run: npm ci 
       - run: ./generate-reference.sh ${{ matrix.branch }}
-      - uses: peter-evans/create-pull-request@v3
+      - name: create-pull-request
+        uses: peter-evans/create-pull-request@v3
         with:
           commit-message: 'feat: Update golem-js API Reference for branch ${{ matrix.branch }}'
           title: 'Update ${{ matrix.branch }} branch'


### PR DESCRIPTION
# Problem
Our current Github actions setup prematurely terminates the reference generation process across all branches if a single one encounters a failure. 

## Background
For instance, on the Alpha branch of `golem-js`, a required script for fixing the reference overview isn't merged yet. This causes the reference generation to fail on Alpha branch, prematurely terminating the process on other branches that, otherwise, would have succeeded.

## Proposed Solution
I propose to modify the Github actions setup to allow the reference generation process to continue on other branches, even if one of them fails.