### PR TITLE
Mini fixes for demo

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -116,7 +116,7 @@ function SearchResult({ result, autocomplete, collection, query }) {
       <div
         id={`${id}-title`}
         aria-hidden="true"
-        className="relative  rounded-lg py-2  pl-3 text-sm text-slate-700 group-aria-selected:bg-slate-100 group-aria-selected:text-primary dark:text-white/50 dark:group-aria-selected:bg-slate-700/30 dark:group-aria-selected:text-white/50"
+        className="relative hover:cursor-pointer rounded-lg py-2  pl-3 text-sm text-slate-700 group-aria-selected:bg-slate-100 group-aria-selected:text-primary dark:text-white/50 dark:group-aria-selected:bg-slate-700/30 dark:group-aria-selected:text-white/50"
       >
         <div className="w-3/5 break-words md:w-3/4">
           <HighlightQuery text={result.title} query={query} />

--- a/src/markdoc/search.mjs
+++ b/src/markdoc/search.mjs
@@ -94,6 +94,10 @@ export default function (nextConfig = {}) {
                     ?.match(/^type:\s*(.*?)\s*$/m)?.[1]
                     .replace('"', '')
                     .replace('"', '')
+                  if (type === 'noindex') {
+                    // Dont index noindex pages
+                    return
+                  }
                   sections = [[title, null, [], type]]
 
                   extractSections(ast, sections)

--- a/src/pages/404.md
+++ b/src/pages/404.md
@@ -1,7 +1,7 @@
 ---
 title: Page Not Found | Golem Docs
 description: "The page you're looking for doesn't exist on the Golem Docs. Explore our site to find relevant content or contact our support for assistance."
-type: page
+type: noindex
 ---
 
 {% customerror errorCode=404 title="Page not found" description="Sorry, we couldn’t find the page you’re looking for." %}

--- a/src/pages/500.md
+++ b/src/pages/500.md
@@ -1,7 +1,7 @@
 ---
 title: 500 Internal Server Error | Golem Docs
 description: Unexpected server issue encountered on the Golem Docs. Our team is working on resolving it. Please check back soon or contact our support
-type: page
+type: noindex
 ---
 
 {% customerror errorCode=500 title="Internal server error!" description="An unexpected error has occurred." %}


### PR DESCRIPTION
## Issue

Currently the search function indexes the custom error 404 and 500 pages, which is not intended. 
<img width="888" alt="image" src="https://github.com/golemfactory/golem-docs/assets/33448819/91d2a5a7-7f21-4a2f-9db2-e0ce50d2dd46">


### Fix
I have now made it so that pages with the type `noindex` doesn't get indexed in the search.
<img width="811" alt="image" src="https://github.com/golemfactory/golem-docs/assets/33448819/d5f5e9cd-a993-42f7-b3c2-efda671807ae">
