### PR TITLE
Update docs according to example change

### DIFF
--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -107,6 +107,7 @@ export default function App({ Component, pageProps }) {
         <Head>
           <title>{pageTitle}</title>
           {description && <meta name="description" content={description} />}
+          <meta name="google-site-verification" content="5fpjcvtgYaJbTGz1kA5h6gRiVz0vpw3UiiBtRBvm7nc" />
         </Head>
         <Layout
           title={title}

--- a/src/pages/docs/creators/javascript/examples/selecting-providers.md
+++ b/src/pages/docs/creators/javascript/examples/selecting-providers.md
@@ -100,7 +100,7 @@ Let's see how to use it:
 
 Note that `customFilter` is a function that accepts a `proposal` object as its parameter and should return `true` or `false` depending on the decision based on the proposal properties.
 
-Our custom function collects pricing data until we have a set of 10 proposals. Then it accepts proposals only if the price is lower than average from the last ten proposals.
+Our custom function collects pricing data until we have a set of 5 proposals. Then it accepts proposals only if the price is lower than average from the last five proposals.
 
 Provider price is calculated as the product of prices defined per specific usage counter.
 


### PR DESCRIPTION
The example now only checks for 5 providers instead of 10 due to a new change in the golem-js repo to fix the examples failure