### PR TITLE
Dont display feedback on homepage

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -261,7 +261,9 @@ export function Layout({
             </div>
 
             <Prose>{children}</Prose>
-            <FeedbackButtons article={true} identifier={router.pathname} />
+            {type == 'page' || isHomePage || is404Page || is500Page ? (
+              null
+            ) : <FeedbackButtons article={true} identifier={router.pathname} /> }
           </article>
         </div>
         {type !== 'page' &&


### PR DESCRIPTION
Since we introduced the component we've made changes and this means that the feedback is asked on home `/` homepage which we don't want. This PR fixes it.
<img width="1512" alt="image" src="https://github.com/golemfactory/golem-docs/assets/33448819/902bb3d0-f7e2-4927-8bbc-03cb8290f32f">
