### PR TITLE
Fix the reference default values page being missing

### DIFF
--- a/generateTypedoc.mjs
+++ b/generateTypedoc.mjs
@@ -34,7 +34,7 @@ async function main() {
   )
 
   // Move default-values.md to the correct location, so we don't overwrite it with reference generation
-  const sourcePath = `${__dirname}/ `
+  const sourcePath = `${__dirname}/src/navigation/customPages/default-values.md`
   const destPath = `${__dirname}/src/pages/docs/golem-js/reference/default-values.md`
   await fs.promises.copyFile(sourcePath, destPath)
 }

--- a/src/pages/docs/golem-js/reference/default-values.md
+++ b/src/pages/docs/golem-js/reference/default-values.md
@@ -1,0 +1,7 @@
+---
+description: Golem JS default values for the TaskExecutor options
+title: A comprehensive guide on the default values used in Golem JS's TaskExecutor options. Understand and customize them effectively.
+type: Guide
+---
+
+{% partial file="customPages/default-values.md" /%}


### PR DESCRIPTION
Currently the default-values in the navbar links to a file that doesn't exist, thus it doesn't work. This PR solves that issue