### PR TITLE
Python with Ray

### DIFF
--- a/src/pages/docs/creators/index.md
+++ b/src/pages/docs/creators/index.md
@@ -34,7 +34,7 @@ Need a backend to offload your system?
 
 {% /selectioncard %}
 
-{% selectioncard icon="ray" title="Ray on Golem Docs" buttonText="Read Ray on Golem Docs" href="/docs/creators/ray" %}
+{% selectioncard icon="ray" title="Python with Ray on Golem" buttonText="Read Ray on Golem Docs" href="/docs/creators/ray" %}
 
 {% selectioncontent %}
 


### PR DESCRIPTION
@cryptobench 
When Python docs got merged the squares on the Create on Golem seem to direct Python to yapapi.
So with Jacek we thought we will change `Ray on Golem Docs` to `Python with Ray on Golem`
It seems too long however - can you have a look, how does it look? :pray: 