### PR TITLE
Ray budget control options description

### DIFF
--- a/src/navigation/docs.js
+++ b/src/navigation/docs.js
@@ -321,6 +321,10 @@ export const navigation = [
                 title: 'Ray CLI',
                 href: '/docs/creators/ray/ray-cli',
               },
+              {
+                title: 'Ray on Golem CLI',
+                href: '/docs/creators/ray/ray-on-golem-cli',
+              },
 	    ],
           },
         ],

--- a/src/navigation/footer.jsx
+++ b/src/navigation/footer.jsx
@@ -213,6 +213,10 @@ export const ray = [
         title: 'Ray CLI',
         href: '/docs/creators/ray/ray-cli',
       },
+      {
+        title: 'Ray on Golem CLI',
+        href: '/docs/creators/ray/ray-on-golem-cli',
+      },
     ],
   },
   {

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -110,30 +110,38 @@ Please [let us know on `#Ray on Golem` discord channel)](https://chat.golem.netw
 
 ### Spending hard limit
 
-Within `provider.parameters` section there is `budget` option.
+Within `provider.parameters` section there is `budget` property.
 It defines the maximum amount of GLMs paid for the whole cluster operations - since `ray up` and until `ray down`.
 
 At the moment, when the spending reach the limit, Ray on Golem will stop spending, effectively terminating the cluster nodes.
 
-<!--
-cost_management:  # TODO: Consider more suitable parameter name
-# Estimated average load and duration for worker that tells cost management to pick the least expensive Golem provider offers first.
-# If not provided, offers will be picked at random.
-# Both values need to be defined or undefined together.
-average_cpu_load: 0.8
-average_duration_minutes: 20
+### Avoiding too expensive providers
 
-# Amount of GLMs for average usage which Golem provider offer will be rejected if exceeded.
-# Requires "average_cpu_load" and "average_duration_minutes" parameters to take effect.
-max_average_usage_cost: 1.5
+You can use `provider.parameters.node_config.cost_management` section to define the limits on providers prices.
+Ray on Golem won't work with providers which exceed any of the following price settings.
 
-# Amount of GLMs for worker initiation which Golem provider offer will be rejected if exceeded.
-max_initial_price: 0.5
 
-# Amount of GLMs for CPU utilisation per second which Golem provider offer will be rejected if exceeded.
-max_cpu_sec_price: 0.0005
+#### Maximum provider prices
 
-# Amount of GLMs for each second that worker runs which Golem provider offer will be rejected if exceeded.
-max_duration_sec_price: 0.0005
+Golem providers charge in three ways. They charge:
+- initial price at start of deployment,
+- cpu usage price for the total time (in seconds) their CPUs spent computing,
+- duration price for the total time (in seconds) they spent up and running,
+
+So for example, if you rented a 3 CPU node for 15 minutes and utilized all three cores for 10 minutes you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 10*60`.
+
+The following properties allow you to reject providers with any of the prices exceeding your limits.
+- `max_initial_price` (recommended value `0.5`)
+- `max_cpu_sec_price` (recommended value `0.0005`)
+- `max_duration_sec_price` (recommended value `0.0005`)
+
+#### Maximum average usage cost
+
+In order to combine, all three prices into one value, have a look at the properties:
+- `average_cpu_load` (recommended value `0.8`)
+- `average_duration_minutes` (recommended value `20`)
+- `max_average_usage_cost` (recommended value `1.5`)
+
+Using those if you plan to use your cluster for 20 minutes, and keep it busy for 80% of the time, you will reject providers that would cost you more than `1.5` GLMs in total.
 
 

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -106,11 +106,16 @@ Supported tags are available on [Golem registry](https://registry.golem.network/
 
 Please [let us know on `#Ray on Golem` discord channel)](https://chat.golem.network/) if you need an image with any specific content. We will be happy to help you.
 
-<!--
 ## Budget management properties
 
-    budget: 2
+### Spending hard limit
 
+Within `provider.parameters` section there is `budget` option.
+It defines the maximum amount of GLMs paid for the whole cluster operations - since `ray up` and until `ray down`.
+
+At the moment, when the spending reach the limit, Ray on Golem will stop spending, effectively terminating the cluster nodes.
+
+<!--
 cost_management:  # TODO: Consider more suitable parameter name
 # Estimated average load and duration for worker that tells cost management to pick the least expensive Golem provider offers first.
 # If not provided, offers will be picked at random.
@@ -132,4 +137,3 @@ max_cpu_sec_price: 0.0005
 max_duration_sec_price: 0.0005
 
 
--->

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -188,8 +188,8 @@ provider:
           # allowing the picking of the least expensive Golem providers' offers first.
           # If not provided, offers will be picked at random.
           # Both values need to be defined or undefined together.
-          expected_cpu_load: 0.8
-          expected_duration_minutes: 20
+          cpu_load: 0.8
+          duration_hours: 20
 
           # Amount of GLMs for expected usage 
           # causing Golem provider offer to be rejected

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -168,8 +168,9 @@ To combine all three prices into one value, have a look at the properties:
 - `average_duration_minutes`
 - `max_average_usage_cost`
 
-Using those if you plan to use your cluster for 20 minutes, and keep it busy for 80% of the time, you will reject providers that would cost you more than `1.5` GLMs in total.
+Using those if you plan to use your cluster for `average_duration_minutes` minutes, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
 
+As an added bonus, all offers will be sorted by computed average usage cost - Ray on Golem will negotiate with the cheapest ones first.
 
 ```yaml
 provider:

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -75,8 +75,8 @@ initialization_commands: []
 
 ### Provider section
 
-The whole "provider" section describes quite a lot of Golem node provider internals. 
-Some of these properties interact with how Ray on Golem works in general, so be careful with those that you're unfamiliar with as changing them may render your cluster unusable.
+The whole "provider" section describes many Golem node provider internals. 
+Some of these properties interact with how Ray on Golem works in general, so be careful with those you're unfamiliar with as changing them may render your cluster unusable.
 
 #### Webserver port
 
@@ -104,28 +104,28 @@ By default, Ray on Golem uses prepackaged VM images including [relatively fresh]
 However, you can use these properties to override the detection and request a specific image. 
 Supported tags are available on [Golem registry](https://registry.golem.network/explore/golem/ray-on-golem).
 
-Please [let us know on `#Ray on Golem` discord channel)](https://chat.golem.network/) if you need an image with any specific content. We will be happy to help you.
+Please [let us know on the `#Ray on Golem` discord channel)](https://chat.golem.network/) if you need an image with any specific content. We will be happy to help you.
 
 ## Budget management properties
 
 ### Spending hard limit
 
-Within `provider.parameters` section there is `budget` property.
-It defines the maximum amount of GLMs paid for the whole cluster operations - since `ray up` and until `ray down`.
+Within `provider.parameters` section there is the `budget` property.
+It defines the maximum amount of GLMs paid for the whole cluster operations - from `ray up` until `ray down`.
 
-At the moment, when the spending reach the limit, Ray on Golem will stop spending, effectively terminating the cluster nodes.
+At the moment, when the spending reaches the limit, Ray on Golem will stop spending, effectively terminating the cluster nodes.
 
-### Avoiding too expensive providers
+### Avoiding too-expensive providers
 
-You can use `provider.parameters.node_config.cost_management` section to define the limits on providers prices.
-Ray on Golem won't work with providers which exceed any of the following price settings.
+You can use `provider.parameters.node_config.cost_management` section to define the limits on providers' prices.
+Ray on Golem won't work with providers who exceed any of the following price settings.
 
 
 #### Maximum provider prices
 
 Golem providers charge in three ways. They charge:
-- initial price at start of image deployment,
-- cpu usage price for the total time (in seconds) their CPUs spent computing,
+- the initial price at the start of image deployment,
+- CPU usage price for the total time (in seconds) their CPUs spent computing,
 - duration price for the total time (in seconds) they spent up and running,
 
 So for example, if you rented a 3 CPU node for 15 minutes and utilized all three cores for 10 minutes you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 10*60`.
@@ -137,7 +137,7 @@ The following properties allow you to reject providers with any of the prices ex
 
 #### Maximum average usage cost
 
-In order to combine all three prices into one value, have a look at the properties:
+To combine all three prices into one value, have a look at the properties:
 - `average_cpu_load` (recommended value `0.8`)
 - `average_duration_minutes` (recommended value `20`)
 - `max_average_usage_cost` (recommended value `1.5`)

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -163,14 +163,14 @@ provider:
 
 #### Choosing the cheapest providers - maximum average usage cost
 
-In order to work with the cheapest provider, we combine all [three prices](#maximum-provider-prices) into one value.
+To work with the cheapest provider, we combine all [three prices](#maximum-provider-prices) into one value.
 
 Have a look at the properties:
 - `average_cpu_load`
 - `average_duration_minutes`
 - `max_average_usage_cost`
 
-Using those if you plan to use your cluster for `average_duration_minutes` minutes, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
+Using those if you plan to use your cluster for `average_duration_minutes`, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
 
 All providers' offers are sorted by estimated average usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
 In this way, it is beneficial even if you miss-estimate the average CPU load and average duration.

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -135,7 +135,7 @@ Ray on Golem won't work with providers who exceed any of the following price set
 #### Maximum provider prices
 
 Golem providers charge in three ways. They charge:
-- the initial price at the start of image deployment - we divide it by the number of CPUs to work with price per CPU,
+- the initial price at the start of image deployment - we divide it by the number of CPUs so that the price is representative of the actual computing power that you pay for,
 - CPU usage price for the total time (in hours) their CPUs spent computing,
 - duration price for the total time (in hours) they spent up and running - we divide it by the number of CPUs to work with price per CPU,
 

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -165,11 +165,11 @@ provider:
 
 To work with the cheapest provider, we combine all [three prices](#maximum-provider-prices) into one value.
 
-Estimate the rough time your cluster will be up, and the expected CPU load during that time. Set `expected_duration_minutes` and `expected_cpu_load` properties to compute each provider's expected usage cost.
+Please estimate the approximate time your application will require the cluster to operate, and the expected CPU load during that time. Then, set the respective `expected_duration_minutes` and `expected_cpu_load` properties to allow Ray on Golem to compute each provider's expected usage cost.
 
-All providers' offers will be sorted by estimated expected usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
+All providers' offers are internally sorted by estimated cost, allowing Ray on Golem to negotiate and sign agreements with the cheapest nodes first.
 
-You might also use `max_expected_usage_cost` to unconditionally cut off providers with too big an expected usage cost (in GLMs).
+You may also use `max_expected_usage_cost` to unconditionally cut off providers with too high an expected usage cost (in GLMs).
 
 ```yaml
 provider:

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -75,8 +75,12 @@ initialization_commands: []
 
 ### Provider section
 
-The whole "provider" section describes many Golem node provider internals. 
-Some of these properties interact with how Ray on Golem works in general, so be careful with those you're unfamiliar with as changing them may render your cluster unusable.
+The whole "provider" section describes various Golem node provider internal parameters. 
+
+Some of these properties influence how Ray on Golem works in general, but we still encourage you to experiment with various settings. 
+The worst that will happen is that you'll need to start your cluster anew. 
+
+We're eager to hear your feedback on the understandability, usability, or interesting usage of those parameters (on the [`#Ray on Golem` discord channel](https://chat.golem.network/))
 
 #### Webserver port
 

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -170,8 +170,8 @@ To combine all three prices into one value, have a look at the properties:
 
 Using those if you plan to use your cluster for `average_duration_minutes` minutes, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
 
-As an added bonus, all offers will be sorted by estimated average usage cost. 
-Ray on Golem will negotiate with the cheapest ones first - this way setting those is beneficial even if you miss-estimate the average CPU load and average duration.
+All providers' offers will be sorted by estimated average usage cost, allowing Ray on Golem will negotiate with the cheapest ones first.
+In this way, it is beneficial even if you miss-estimate the average CPU load and average duration.
 
 ```yaml
 provider:

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -170,7 +170,7 @@ To combine all three prices into one value, have a look at the properties:
 
 Using those if you plan to use your cluster for `average_duration_minutes` minutes, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
 
-All providers' offers will be sorted by estimated average usage cost, allowing Ray on Golem will negotiate with the cheapest ones first.
+All providers' offers are sorted by estimated average usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
 In this way, it is beneficial even if you miss-estimate the average CPU load and average duration.
 
 ```yaml

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -90,8 +90,8 @@ When you move to the mainnet, the `network` property needs to be changed to `pol
 
 ```yaml
 # Blockchain used for payments. 
-# Goerli means running free nodes on testnet, 
-# Polygon is for mainnet operations.
+# "goerli" means running free nodes on testnet, 
+# "polygon" is for mainnet operations.
 network: "goerli"
 ```
 
@@ -105,3 +105,31 @@ However, you can use these properties to override the detection and request a sp
 Supported tags are available on [Golem registry](https://registry.golem.network/explore/golem/ray-on-golem).
 
 Please [let us know on `#Ray on Golem` discord channel)](https://chat.golem.network/) if you need an image with any specific content. We will be happy to help you.
+
+<!--
+## Budget management properties
+
+    budget: 2
+
+cost_management:  # TODO: Consider more suitable parameter name
+# Estimated average load and duration for worker that tells cost management to pick the least expensive Golem provider offers first.
+# If not provided, offers will be picked at random.
+# Both values need to be defined or undefined together.
+average_cpu_load: 0.8
+average_duration_minutes: 20
+
+# Amount of GLMs for average usage which Golem provider offer will be rejected if exceeded.
+# Requires "average_cpu_load" and "average_duration_minutes" parameters to take effect.
+max_average_usage_cost: 1.5
+
+# Amount of GLMs for worker initiation which Golem provider offer will be rejected if exceeded.
+max_initial_price: 0.5
+
+# Amount of GLMs for CPU utilisation per second which Golem provider offer will be rejected if exceeded.
+max_cpu_sec_price: 0.0005
+
+# Amount of GLMs for each second that worker runs which Golem provider offer will be rejected if exceeded.
+max_duration_sec_price: 0.0005
+
+
+-->

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -165,15 +165,11 @@ provider:
 
 To work with the cheapest provider, we combine all [three prices](#maximum-provider-prices) into one value.
 
-Have a look at the properties:
-- `average_cpu_load`
-- `average_duration_minutes`
-- `max_average_usage_cost`
+Estimate rough time your cluster will be up, and average CPU load during that time. Set `average_duration_minutes` and `average_cpu_load` properties to compute each provider's expected average usage cost.
 
-Using those if you plan to use your cluster for `average_duration_minutes`, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
+All providers' offers will be sorted by estimated average usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
 
-All providers' offers are sorted by estimated average usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
-In this way, it is beneficial even if you miss-estimate the average CPU load and average duration.
+You might also use `max_average_usage_cost` to unconditionally cut off providers with too big average usage cost (in GLMs).
 
 ```yaml
 provider:

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -110,7 +110,7 @@ Please [let us know on the `#Ray on Golem` discord channel)](https://chat.golem.
 
 ### Spending hard limit
 
-Within `provider.parameters` section there is the `budget` property.
+Within `provider.parameters` section there is the `budget_limit` property.
 It defines the maximum amount of GLMs paid for the whole cluster operations - from `ray up` until `ray down`.
 
 At the moment, when the spending reaches the limit, Ray on Golem will stop spending, effectively terminating the cluster nodes.
@@ -120,12 +120,12 @@ provider:
   parameters:
 
     # Maximum amount of GLMs that's going to be spent for the whole cluster
-    budget: 2
+    budget_limit: 2
 ```
 
 ### Avoiding too-expensive providers
 
-You can use `provider.parameters.node_config.cost_management` section to define the limits on providers' prices.
+You can use `provider.parameters.node_config.budget_control` section to define the limits on providers' prices.
 Ray on Golem won't work with providers who exceed any of the following price settings.
 
 #### Maximum provider prices
@@ -146,7 +146,7 @@ The following properties allow you to reject providers with any of the prices ex
 provider:
   parameters:
     node_config:
-      cost_management:
+      budget_control:
 
         # Amount of GLMs for worker initiation 
         # causing Golem provider offer to be rejected
@@ -161,31 +161,31 @@ provider:
         max_duration_sec_price: 0.0005
 ```
 
-#### Choosing the cheapest providers - maximum average usage cost
+#### Choosing the cheapest providers - maximum expected usage cost
 
 To work with the cheapest provider, we combine all [three prices](#maximum-provider-prices) into one value.
 
-Estimate the rough time your cluster will be up, and the average CPU load during that time. Set `average_duration_minutes` and `average_cpu_load` properties to compute each provider's expected average usage cost.
+Estimate the rough time your cluster will be up, and the expected CPU load during that time. Set `expected_duration_minutes` and `expected_cpu_load` properties to compute each provider's expected usage cost.
 
-All providers' offers will be sorted by estimated average usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
+All providers' offers will be sorted by estimated expected usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
 
-You might also use `max_average_usage_cost` to unconditionally cut off providers with too big an average usage cost (in GLMs).
+You might also use `max_expected_usage_cost` to unconditionally cut off providers with too big an expected usage cost (in GLMs).
 
 ```yaml
 provider:
   parameters:
     node_config:
-      cost_management:
+      budget_control:
 
-        # Estimated average load and duration for worker 
+        # Estimated expected load and duration for worker 
         # allowing the picking of the least expensive Golem providers' offers first.
         # If not provided, offers will be picked at random.
         # Both values need to be defined or undefined together.
-        average_cpu_load: 0.8
-        average_duration_minutes: 20
+        expected_cpu_load: 0.8
+        expected_duration_minutes: 20
 
-        # Amount of GLMs for average usage 
+        # Amount of GLMs for expected usage 
         # causing Golem provider offer to be rejected
-        # Requires both `average_cpu_load` and `average_duration_minutes`
-        max_average_usage_cost: 1.5
+        # Requires both `expected_cpu_load` and `expected_duration_minutes`
+        max_expected_usage_cost: 1.5
 ```

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -80,7 +80,7 @@ The whole "provider" section describes various Golem node provider internal para
 Some of these properties influence how Ray on Golem works in general, but we still encourage you to experiment with different settings. 
 The worst that will happen is that you'll need to start your cluster anew. 
 
-We're eager to hear your feedback on the understandability, usability, or interesting usage of those parameters (on the [`#Ray on Golem` discord channel](https://chat.golem.network/))
+We're eager to hear your feedback on the clarity, usability, or interesting usage of those parameters (on the [`#Ray on Golem` discord channel](https://chat.golem.network/))
 
 #### Webserver port
 

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -171,7 +171,7 @@ To combine all three prices into one value, have a look at the properties:
 Using those if you plan to use your cluster for `average_duration_minutes` minutes, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
 
 As an added bonus, all offers will be sorted by estimated average usage cost. 
-Ray on Golem will negotiate with the cheapest ones first - this way setting those is beneficial even if you miss-estimate average cpu load and average duration.
+Ray on Golem will negotiate with the cheapest ones first - this way setting those is beneficial even if you miss-estimate the average CPU load and average duration.
 
 ```yaml
 provider:

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -170,7 +170,8 @@ To combine all three prices into one value, have a look at the properties:
 
 Using those if you plan to use your cluster for `average_duration_minutes` minutes, and keep it busy for `average_cpu_load` of the time, you will reject providers that would cost you more than `max_average_usage_cost` GLMs in total.
 
-As an added bonus, all offers will be sorted by computed average usage cost - Ray on Golem will negotiate with the cheapest ones first.
+As an added bonus, all offers will be sorted by estimated average usage cost. 
+Ray on Golem will negotiate with the cheapest ones first - this way setting those is beneficial even if you miss-estimate average cpu load and average duration.
 
 ```yaml
 provider:

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -115,11 +115,18 @@ It defines the maximum amount of GLMs paid for the whole cluster operations - fr
 
 At the moment, when the spending reaches the limit, Ray on Golem will stop spending, effectively terminating the cluster nodes.
 
+```yaml
+provider:
+  parameters:
+
+    # Maximum amount of GLMs that's going to be spent for the whole cluster
+    budget: 2
+```
+
 ### Avoiding too-expensive providers
 
 You can use `provider.parameters.node_config.cost_management` section to define the limits on providers' prices.
 Ray on Golem won't work with providers who exceed any of the following price settings.
-
 
 #### Maximum provider prices
 
@@ -135,6 +142,25 @@ The following properties allow you to reject providers with any of the prices ex
 - `max_cpu_sec_price` (recommended value `0.0005`)
 - `max_duration_sec_price` (recommended value `0.0005`)
 
+```yaml
+provider:
+  parameters:
+    node_config:
+      cost_management:
+
+        # Amount of GLMs for worker initiation 
+        # causing Golem provider offer to be rejected
+        max_initial_price: 0.5
+
+        # Amount of GLMs for CPU utilisation per second 
+        # causing Golem provider offer to be rejected
+        max_cpu_sec_price: 0.0005
+
+        # Amount of GLMs for each second that worker runs 
+        # causing Golem provider offer to be rejected
+        max_duration_sec_price: 0.0005
+```
+
 #### Maximum average usage cost
 
 To combine all three prices into one value, have a look at the properties:
@@ -145,3 +171,21 @@ To combine all three prices into one value, have a look at the properties:
 Using those if you plan to use your cluster for 20 minutes, and keep it busy for 80% of the time, you will reject providers that would cost you more than `1.5` GLMs in total.
 
 
+```yaml
+provider:
+  parameters:
+    node_config:
+      cost_management:
+
+        # Estimated average load and duration for worker 
+        # allowing the picking of the least expensive Golem providers' offers first.
+        # If not provided, offers will be picked at random.
+        # Both values need to be defined or undefined together.
+        average_cpu_load: 0.8
+        average_duration_minutes: 20
+
+        # Amount of GLMs for average usage 
+        # causing Golem provider offer to be rejected
+        # Requires both `average_cpu_load` and `average_duration_minutes`
+        max_average_usage_cost: 1.5
+```

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -135,12 +135,12 @@ Golem providers charge in three ways. They charge:
 - CPU usage price for the total time (in seconds) their CPUs spent computing,
 - duration price for the total time (in seconds) they spent up and running,
 
-So for example, if you rented a 3 CPU node for 15 minutes and utilized all three cores for 10 minutes you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 10*60`.
+So for example, if you rent a 3 CPU node for 15 minutes and utilized each core in 80% you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
 
 The following properties allow you to reject providers with any of the prices exceeding your limits.
-- `max_initial_price` (recommended value `0.5`)
-- `max_cpu_sec_price` (recommended value `0.0005`)
-- `max_duration_sec_price` (recommended value `0.0005`)
+- `max_initial_price`
+- `max_cpu_sec_price`
+- `max_duration_sec_price`
 
 ```yaml
 provider:
@@ -164,9 +164,9 @@ provider:
 #### Maximum average usage cost
 
 To combine all three prices into one value, have a look at the properties:
-- `average_cpu_load` (recommended value `0.8`)
-- `average_duration_minutes` (recommended value `20`)
-- `max_average_usage_cost` (recommended value `1.5`)
+- `average_cpu_load`
+- `average_duration_minutes`
+- `max_average_usage_cost`
 
 Using those if you plan to use your cluster for 20 minutes, and keep it busy for 80% of the time, you will reject providers that would cost you more than `1.5` GLMs in total.
 

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -161,9 +161,11 @@ provider:
         max_duration_sec_price: 0.0005
 ```
 
-#### Maximum average usage cost
+#### Choosing the cheapest providers - maximum average usage cost
 
-To combine all three prices into one value, have a look at the properties:
+In order to work with the cheapest provider, we combine all [three prices](#maximum-provider-prices) into one value.
+
+Have a look at the properties:
 - `average_cpu_load`
 - `average_duration_minutes`
 - `max_average_usage_cost`

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -135,9 +135,9 @@ Ray on Golem won't work with providers who exceed any of the following price set
 #### Maximum provider prices
 
 Golem providers charge in three ways. They charge:
-- the initial price at the start of image deployment - we divide it by number of CPUs to work with price per CPU,
+- the initial price at the start of image deployment - we divide it by the number of CPUs to work with price per CPU,
 - CPU usage price for the total time (in hours) their CPUs spent computing,
-- duration price for the total time (in hours) they spent up and running - we divide it by number of CPUs to work with price per CPU,
+- duration price for the total time (in hours) they spent up and running - we divide it by the number of CPUs to work with price per CPU,
 
 So for example, if you rent a 3-CPU node for half an hour and the average load is 0.8 per CPU you will be charged 
 `3 * initial_price_per_cpu + 3 * duration_price_per_cpu * 0.5 + 3 * cpu_usage_price * 0.8 * 0.5`.
@@ -161,7 +161,7 @@ provider:
         # causing Golem provider offer to be rejected
         max_cpu_hour_price: 0.5 
 
-        # Amount of GLMs for each CPU for each hour that worker runs 
+        # Amount of GLMs for each CPU for each hour that the worker runs 
         # causing Golem provider offer to be rejected
         max_duration_hour_price: 0.5
 ```

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -124,7 +124,7 @@ provider:
   parameters:
 
     # Maximum amount of GLMs that's going to be spent for the whole cluster
-    total_budget: 2
+    total_budget: 5
 ```
 
 ### Avoiding too-expensive providers
@@ -189,7 +189,7 @@ provider:
           # If not provided, offers will be picked at random.
           # Both values need to be defined or undefined together.
           cpu_load: 0.8
-          duration_hours: 20
+          duration_hours: 0.5
 
           # Amount of GLMs for expected usage 
           # causing Golem provider offer to be rejected

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -135,7 +135,7 @@ Golem providers charge in three ways. They charge:
 - CPU usage price for the total time (in seconds) their CPUs spent computing,
 - duration price for the total time (in seconds) they spent up and running,
 
-So for example, if you rent a 3 CPU node for 15 minutes and the average load is 80% you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
+So for example, if you rent a 3-CPU node for 15 minutes and the average load is 0.8 per CPU you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
 
 The following properties allow you to reject providers with any of the prices exceeding your limits.
 - `max_initial_price`

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -135,7 +135,7 @@ Golem providers charge in three ways. They charge:
 - CPU usage price for the total time (in seconds) their CPUs spent computing,
 - duration price for the total time (in seconds) they spent up and running,
 
-So for example, if you rent a 3 CPU node for 15 minutes and utilize each core 80% of the time you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
+So for example, if you rent a 3 CPU node for 15 minutes and average load is 80% you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
 
 The following properties allow you to reject providers with any of the prices exceeding your limits.
 - `max_initial_price`

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -135,7 +135,7 @@ Golem providers charge in three ways. They charge:
 - CPU usage price for the total time (in seconds) their CPUs spent computing,
 - duration price for the total time (in seconds) they spent up and running,
 
-So for example, if you rent a 3 CPU node for 15 minutes and average load is 80% you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
+So for example, if you rent a 3 CPU node for 15 minutes and the average load is 80% you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
 
 The following properties allow you to reject providers with any of the prices exceeding your limits.
 - `max_initial_price`
@@ -165,11 +165,11 @@ provider:
 
 To work with the cheapest provider, we combine all [three prices](#maximum-provider-prices) into one value.
 
-Estimate rough time your cluster will be up, and average CPU load during that time. Set `average_duration_minutes` and `average_cpu_load` properties to compute each provider's expected average usage cost.
+Estimate the rough time your cluster will be up, and the average CPU load during that time. Set `average_duration_minutes` and `average_cpu_load` properties to compute each provider's expected average usage cost.
 
 All providers' offers will be sorted by estimated average usage cost, allowing Ray on Golem to negotiate with the cheapest nodes first.
 
-You might also use `max_average_usage_cost` to unconditionally cut off providers with too big average usage cost (in GLMs).
+You might also use `max_average_usage_cost` to unconditionally cut off providers with too big an average usage cost (in GLMs).
 
 ```yaml
 provider:

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -106,7 +106,7 @@ Supported tags are available on [Golem registry](https://registry.golem.network/
 
 Please [let us know on the `#Ray on Golem` discord channel)](https://chat.golem.network/) if you need an image with any specific content. We will be happy to help you.
 
-## Budget management properties
+## Budget control
 
 ### Spending hard limit
 

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -77,7 +77,7 @@ initialization_commands: []
 
 The whole "provider" section describes various Golem node provider internal parameters. 
 
-Some of these properties influence how Ray on Golem works in general, but we still encourage you to experiment with various settings. 
+Some of these properties influence how Ray on Golem works in general, but we still encourage you to experiment with different settings. 
 The worst that will happen is that you'll need to start your cluster anew. 
 
 We're eager to hear your feedback on the understandability, usability, or interesting usage of those parameters (on the [`#Ray on Golem` discord channel](https://chat.golem.network/))

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -137,7 +137,7 @@ Ray on Golem won't work with providers who exceed any of the following price set
 Golem providers charge in three ways. They charge:
 - the initial price at the start of image deployment - we divide it by the number of CPUs so that the price is representative of the actual computing power that you pay for,
 - CPU usage price for the total time (in hours) their CPUs spent computing,
-- duration price for the total time (in hours) they spent up and running - we divide it by the number of CPUs to work with price per CPU,
+- duration price for the total time (in hours) they spent up and running - again, we divide it by the number of CPUs to get a fair comparison,
 
 So for example, if you rent a 3-CPU node for half an hour and the average load is 0.8 per CPU you will be charged 
 `3 * initial_price_per_cpu + 3 * duration_price_per_cpu * 0.5 + 3 * cpu_usage_price * 0.8 * 0.5`.

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -78,7 +78,7 @@ initialization_commands: []
 The whole "provider" section describes various Golem node provider internal parameters. 
 
 Some of these properties influence how Ray on Golem works in general, but we still encourage you to experiment with different settings. 
-The worst that will happen is that you'll need to start your cluster anew. 
+The worst that may happen is that you'll need to revert to a previous working setup and start your cluster anew. 
 
 We're eager to hear your feedback on the clarity, usability, or interesting usage of those parameters (on the [`#Ray on Golem` discord channel](https://chat.golem.network/))
 

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -124,7 +124,7 @@ Ray on Golem won't work with providers which exceed any of the following price s
 #### Maximum provider prices
 
 Golem providers charge in three ways. They charge:
-- initial price at start of deployment,
+- initial price at start of image deployment,
 - cpu usage price for the total time (in seconds) their CPUs spent computing,
 - duration price for the total time (in seconds) they spent up and running,
 
@@ -137,7 +137,7 @@ The following properties allow you to reject providers with any of the prices ex
 
 #### Maximum average usage cost
 
-In order to combine, all three prices into one value, have a look at the properties:
+In order to combine all three prices into one value, have a look at the properties:
 - `average_cpu_load` (recommended value `0.8`)
 - `average_duration_minutes` (recommended value `20`)
 - `max_average_usage_cost` (recommended value `1.5`)

--- a/src/pages/docs/creators/ray/cluster-yaml.md
+++ b/src/pages/docs/creators/ray/cluster-yaml.md
@@ -135,7 +135,7 @@ Golem providers charge in three ways. They charge:
 - CPU usage price for the total time (in seconds) their CPUs spent computing,
 - duration price for the total time (in seconds) they spent up and running,
 
-So for example, if you rent a 3 CPU node for 15 minutes and utilized each core in 80% you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
+So for example, if you rent a 3 CPU node for 15 minutes and utilized each core in 80% of the time you will be charged `initial_price + duration_price * 15*60 + cpu_usage_price * 3 * 0.8 * 15*60`.
 
 The following properties allow you to reject providers with any of the prices exceeding your limits.
 - `max_initial_price`

--- a/src/pages/docs/creators/ray/index.md
+++ b/src/pages/docs/creators/ray/index.md
@@ -73,10 +73,10 @@ The basic flow of working with Ray and Ray on Golem consists of:
 
 ## How to start
 
-You need a piece of code to execute on Golem. Once you have a Ray app, you can immediately proceed to [launching it on Golem](/docs/creators/ray/setup-tutorial).
-You can also use [our example apps](https://github.com/golemfactory/golem-ray/tree/main/examples) to play with Ray on Golem. 
+You'll need a piece of code to execute on Golem. If you already have some Ray application, you can immediately proceed to [launching it on Golem](/docs/creators/ray/setup-tutorial).
+Otherwise, feel free to experiment with [our example apps](https://github.com/golemfactory/golem-ray/tree/main/examples). 
 
-You can also check out a more detailed explanation of [simple ray tasks app](/docs/creators/ray/basic-ray-tasks-usage-tutorial) and a more sophisticated [bridge simulation app](/docs/creators/ray/conversion-to-ray-on-golem-tutorial).
+Once you get the hang of it, we invite you to have a look at the detailed explanation of [simple ray tasks app](/docs/creators/ray/basic-ray-tasks-usage-tutorial) and a more sophisticated [bridge simulation app](/docs/creators/ray/conversion-to-ray-on-golem-tutorial).
 
 If you have any questions, comments, insights, praises, or doubts about these docs and Ray on Golem in general please don't hesitate to reach out to us either on
 - [`#Ray on Golem` discord channel](https://chat.golem.network/) 

--- a/src/pages/docs/creators/ray/index.md
+++ b/src/pages/docs/creators/ray/index.md
@@ -18,6 +18,7 @@ We will use **Ray** to parallelize the code and **Ray on Golem** to execute it.
 - [Converting a real-life use case to Ray on Golem](/docs/creators/ray/conversion-to-ray-on-golem-tutorial) - example of a little bit more practical Ray on Golem usage
 - [Cluster yaml](/docs/creators/ray/cluster-yaml) - details of configuration options of Ray on Golem cluster yaml
 - [Ray CLI](/docs/creators/ray/ray-cli) - details of Ray command line options used with Ray on Golem
+- [Ray on Golem CLI](/docs/creators/ray/ray-on-golem-cli) - details of Ray on Golem command line options
 - [Troubleshooting](/docs/creators/ray/troubleshooting) - hopefully helpful tips on what to do when something goes wrong
 
 

--- a/src/pages/docs/creators/ray/index.md
+++ b/src/pages/docs/creators/ray/index.md
@@ -58,7 +58,7 @@ When your application is ready, and you need more power, you should move to the 
 Payments within the Golem Network take place on the [Polygon](https://polygon.technology) blockchain and require some GLM tokens (to pay the providers) and MATIC (for payment transaction fees).
 Feel free to learn more about [mainnet payments and funding your Ray on Golem](/docs/creators/javascript/guides/switching-to-mainnet).
 
-When you have the tokens you need to configure `network: "polygon"` in the cluster yaml file ([more details](/docs/creators/ray/cluster-yaml#network))
+When you have the tokens you need to configure `payment_network: "polygon"` in the cluster yaml file ([more details](/docs/creators/ray/cluster-yaml#network))
 
 Check out [the machines](https://stats.golem.network/network/providers/online) ready to execute your payloads.
 

--- a/src/pages/docs/creators/ray/ray-on-golem-cli.md
+++ b/src/pages/docs/creators/ray/ray-on-golem-cli.md
@@ -36,7 +36,7 @@ Gathering stats data done
 Proposals count:
 Initial: 48
 Not blacklisted: 48
-Passed Reject if max_average_usage_cost exceeds 1.5: 48
+Passed Reject if max_expected_usage_cost exceeds 1.5: 48
 Passed Reject if price_initial exceeds 0.5: 48
 Passed Reject if price_cpu_sec exceeds 0.0005: 48
 Passed Reject if price_duration_sec exceeds 0.0005: 48
@@ -62,7 +62,7 @@ Use `--duration` parameter to set how long you want to be scanning the network. 
 
 - `Initial` proposals found during the scan (there might be more than one proposal per provider)
 - `Not blacklisted` - proposals comming from non-blacklisted providers (we blacklist providers with a history of misbehaving)
-- `Passed Reject if max_expected_usage_cost exceeds` - proposals not exceeding your [`max_expected_usage_cost` setting](/docs/creators/ray/cluster-yaml#choosing-the-cheapest-providers-maximum-average-usage-cost)
+- `Passed Reject if max_expected_usage_cost exceeds` - proposals not exceeding your [`max_expected_usage_cost` setting](/docs/creators/ray/cluster-yaml#choosing-the-cheapest-providers-maximum-expected-usage-cost)
 - `Passed Reject if price_initial exceeds` - proposals not exceeding your [`price_initial` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
 - `Passed Reject if price_cpu_sec exceeds` - proposals not exceeding your [`price_cpu_sec` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
 - `Passed Reject if price_duration_sec exceeds` - proposals not exceeding your [`price_duration_sec` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)

--- a/src/pages/docs/creators/ray/ray-on-golem-cli.md
+++ b/src/pages/docs/creators/ray/ray-on-golem-cli.md
@@ -22,7 +22,7 @@ Ray on Golem supports the following commands
 The tool scans the network and gives you an overview of the availability of the providers.
 It allows you to test the settings of your [cluster yaml](/docs/creators/ray/cluster-yaml) file. 
 
-You can use it to test different [budget control](/docs/creators/ray/cluster-yaml#avoiding-too-expensive-providers) settings, both on [the testnet and the mainnet](/docs/creators/ray/cluster-yaml#network).
+You can use it to verify and fine-tune different [budget control](/docs/creators/ray/cluster-yaml#avoiding-too-expensive-providers) parameters, both on [the testnet and the mainnet](/docs/creators/ray/cluster-yaml#network).
 
 ### Example usage
 
@@ -52,11 +52,12 @@ Failed to send proposal response! 500: {"message":"Failed to send response for P
 
 ### Duration
 
-Golem Network is peer-to-peer, which means that providers' proposals are not always available at first. They get broadcasted from time to time.
+Golem Network is peer-to-peer, which means there is no central registry of providers offers. Therefore, 
+providers proposals are not immediately available to a newly-connected requestor. They get re-broadcasted at a certain interval and accumulate over time.
 
-Negotiating with a provider also takes some time.
+Additionally, negotiating with individual providers also takes some time.
 
-Use the `--duration` parameter to set how long you want to be scanning the network. It gives time for gathering proposals and negotiating them
+Use the `--duration` parameter to set how long you want your network scan to last. It allows time to gather and negotiate the incoming proposals
 
 ### Output
 

--- a/src/pages/docs/creators/ray/ray-on-golem-cli.md
+++ b/src/pages/docs/creators/ray/ray-on-golem-cli.md
@@ -22,7 +22,8 @@ Ray on Golem supports the following commands
 The tool scans the network and gives you an overview of the availability of the providers.
 It allows you to test the settings of your [cluster yaml](/docs/creators/ray/cluster-yaml) file. 
 
-You can use it to verify and fine-tune different [budget control](/docs/creators/ray/cluster-yaml#avoiding-too-expensive-providers) parameters, both on [the testnet and the mainnet](/docs/creators/ray/cluster-yaml#network).
+You can use it to verify and fine-tune different [budget control](/docs/creators/ray/cluster-yaml#avoiding-too-expensive-providers) parameters, 
+both on [the testnet and the mainnet](/docs/creators/ray/cluster-yaml#network).
 
 ### Example usage
 
@@ -38,8 +39,8 @@ Initial: 48
 Not blacklisted: 48
 Passed Reject if max_expected_usage_cost exceeds 1.5: 48
 Passed Reject if price_initial exceeds 0.5: 48
-Passed Reject if price_cpu_sec exceeds 0.0005: 48
-Passed Reject if price_duration_sec exceeds 0.0005: 48
+Passed Reject if price_cpu_hour exceeds 0.5: 48
+Passed Reject if price_duration_hour exceeds 0.5: 48
 Negotiation initialized: 48 
 Negotiated successfully: 37
 
@@ -65,8 +66,8 @@ Use the `--duration` parameter to set how long you want your network scan to las
 - `Not blacklisted` - proposals coming from non-blacklisted providers (we blacklist providers with a history of misbehaving)
 - `Passed Reject if max_expected_usage_cost exceeds` - proposals not exceeding your [`max_expected_usage_cost` setting](/docs/creators/ray/cluster-yaml#choosing-the-cheapest-providers-maximum-expected-usage-cost)
 - `Passed Reject if price_initial exceeds` - proposals not exceeding your [`price_initial` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
-- `Passed Reject if price_cpu_sec exceeds` - proposals not exceeding your [`price_cpu_sec` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
-- `Passed Reject if price_duration_sec exceeds` - proposals not exceeding your [`price_duration_sec` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
+- `Passed Reject if price_cpu_hour exceeds` - proposals not exceeding your [`price_cpu_hour` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
+- `Passed Reject if price_duration_hour exceeds` - proposals not exceeding your [`price_duration_hour` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
 - `Negotiation initialized` - proposals passing all the above limitations
 - `Negotiated successfully` - providers ready to deploy Ray on Golem image
 

--- a/src/pages/docs/creators/ray/ray-on-golem-cli.md
+++ b/src/pages/docs/creators/ray/ray-on-golem-cli.md
@@ -69,7 +69,7 @@ Use the `--duration` parameter to set how long you want your network scan to las
 - `Passed Reject if price_cpu_hour exceeds` - proposals not exceeding your [`price_cpu_hour` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
 - `Passed Reject if price_duration_hour exceeds` - proposals not exceeding your [`price_duration_hour` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
 - `Negotiation initialized` - proposals passing all the above limitations
-- `Negotiated successfully` - providers ready to deploy Ray on Golem image
+- `Negotiated successfully` - providers ready to deploy the Ray on Golem image
 
 At the end of the output, you can see the reasons for failing negotiations. 
 The most interesting are the reasons around providers' outbound settings, but for now, we don't offer any actionable follow-up.

--- a/src/pages/docs/creators/ray/ray-on-golem-cli.md
+++ b/src/pages/docs/creators/ray/ray-on-golem-cli.md
@@ -13,13 +13,13 @@ This article explains the commands available, which are useful when working with
 
 ## Commands Overview
 
-Ray on Golem supports the followig commands
+Ray on Golem supports the following commands
 - `ray-on-golem network-stats golem-cluster.yaml` scans the network and offers information about available providers ([details](#network-stats))
 - `ray-on-golem webserver` starts Golem requestor service controlling the providers used by the cluster
 
 ## Network stats
 
-The tool scans the network and gives you overview of the availability of the providers.
+The tool scans the network and gives you an overview of the availability of the providers.
 It allows you to test the settings of your [cluster yaml](/docs/creators/ray/cluster-yaml) file. 
 
 You can use it to test different [budget control](/docs/creators/ray/cluster-yaml#avoiding-too-expensive-providers) settings, both on [the testnet and the mainnet](/docs/creators/ray/cluster-yaml#network).
@@ -54,14 +54,14 @@ Failed to send proposal response! 500: {"message":"Failed to send response for P
 
 Golem Network is peer-to-peer, which means that providers' proposals are not always available at first. They get broadcasted from time to time.
 
-Negotiating with a provider also takes up some time.
+Negotiating with a provider also takes some time.
 
-Use `--duration` parameter to set how long you want to be scanning the network. It gives time for gathering proposals and negotiating them
+Use the `--duration` parameter to set how long you want to be scanning the network. It gives time for gathering proposals and negotiating them
 
 ### Output
 
 - `Initial` proposals found during the scan (there might be more than one proposal per provider)
-- `Not blacklisted` - proposals comming from non-blacklisted providers (we blacklist providers with a history of misbehaving)
+- `Not blacklisted` - proposals coming from non-blacklisted providers (we blacklist providers with a history of misbehaving)
 - `Passed Reject if max_expected_usage_cost exceeds` - proposals not exceeding your [`max_expected_usage_cost` setting](/docs/creators/ray/cluster-yaml#choosing-the-cheapest-providers-maximum-expected-usage-cost)
 - `Passed Reject if price_initial exceeds` - proposals not exceeding your [`price_initial` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
 - `Passed Reject if price_cpu_sec exceeds` - proposals not exceeding your [`price_cpu_sec` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
@@ -69,12 +69,12 @@ Use `--duration` parameter to set how long you want to be scanning the network. 
 - `Negotiation initialized` - proposals passing all the above limitations
 - `Negotiated successfully` - providers ready to deploy Ray on Golem image
 
-At the end of the output you can see the reasons of failing negotiations. 
-The most interesting are the reasons around providers' outbound settings, but for now we don't offer any actionable follow up.
+At the end of the output, you can see the reasons for failing negotiations. 
+The most interesting are the reasons around providers' outbound settings, but for now, we don't offer any actionable follow-up.
 
 ### Nodes availability
 
 The scanning ends with the successful negotiations - the `Negotiated successfully` line shows you the potential size of your cluster.
-Notice that the availability is dynamic - providers might be hired by someone else, more providers might become available, and also more providers might get discovered while your cluster is alive.
+Notice that the availability is dynamic - providers might be hired by someone else, more providers might become available, and more providers might get discovered while your cluster is alive.
 
-The last thing is the image deployment. When starting the actual cluster (with `ray up`) the providers might also fail to start Ray on Golem image. This might decrease the maximum size of your cluster too.
+The last thing is the image deployment. When starting the actual cluster (with `ray up`) the providers might also fail to start the Ray on Golem image. This might decrease the maximum size of your cluster too.

--- a/src/pages/docs/creators/ray/ray-on-golem-cli.md
+++ b/src/pages/docs/creators/ray/ray-on-golem-cli.md
@@ -1,0 +1,80 @@
+---
+title: Ray on Golem CLI 
+pageTitle: Ray on Golem CLI In-Depth Guide
+description: Explore the nuances of running Ray on Golem command-line tools 
+type: article 
+---
+
+# Ray on Golem CLI 
+
+Ray on Golem exposes a command line interface to help you manage the cluster.
+
+This article explains the commands available, which are useful when working with Ray on Golem.
+
+## Commands Overview
+
+Ray on Golem supports the followig commands
+- `ray-on-golem network-stats golem-cluster.yaml` scans the network and offers information about available providers ([details](#network-stats))
+- `ray-on-golem webserver` starts Golem requestor service controlling the providers used by the cluster
+
+## Network stats
+
+The tool scans the network and gives you overview of the availability of the providers.
+It allows you to test the settings of your [cluster yaml](/docs/creators/ray/cluster-yaml) file. 
+
+You can use it to test different [budget control](/docs/creators/ray/cluster-yaml#avoiding-too-expensive-providers) settings, both on [the testnet and the mainnet](/docs/creators/ray/cluster-yaml#network).
+
+### Example usage
+
+```bash
+ray-on-golem network-stats golem-cluster.yaml --duration 5
+```
+```
+Gathering stats data for 5 minutes...
+Gathering stats data done
+
+Proposals count:
+Initial: 48
+Not blacklisted: 48
+Passed Reject if max_average_usage_cost exceeds 1.5: 48
+Passed Reject if price_initial exceeds 0.5: 48
+Passed Reject if price_cpu_sec exceeds 0.0005: 48
+Passed Reject if price_duration_sec exceeds 0.0005: 48
+Negotiation initialized: 48 
+Negotiated successfully: 37
+
+Negotiation errors:
+Outbound rejected because: Everyone rule didn't match whitelist ; Audited-Payload rule requires manifest signature ; Partner rule requires node descriptor ; : 4
+No capacity available. Reached Agreements limit: 1: 2
+Failed to send proposal response! Request timed out: 1
+Failed to send proposal response! 500: {"message":"Failed to send response for Proposal [***]. Error: Countering Proposal [***] GSB error: GSB failure: Net: error forwarding message: Connection timed out.."}: 1
+```
+
+### Duration
+
+Golem Network is peer-to-peer, which means that providers' proposals are not always available at first. They get broadcasted from time to time.
+
+Negotiating with a provider also takes up some time.
+
+Use `--duration` parameter to set how long you want to be scanning the network. It gives time for gathering proposals and negotiating them
+
+### Output
+
+- `Initial` proposals found during the scan (there might be more than one proposal per provider)
+- `Not blacklisted` - proposals comming from non-blacklisted providers (we blacklist providers with a history of misbehaving)
+- `Passed Reject if max_expected_usage_cost exceeds` - proposals not exceeding your [`max_expected_usage_cost` setting](/docs/creators/ray/cluster-yaml#choosing-the-cheapest-providers-maximum-average-usage-cost)
+- `Passed Reject if price_initial exceeds` - proposals not exceeding your [`price_initial` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
+- `Passed Reject if price_cpu_sec exceeds` - proposals not exceeding your [`price_cpu_sec` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
+- `Passed Reject if price_duration_sec exceeds` - proposals not exceeding your [`price_duration_sec` setting](/docs/creators/ray/cluster-yaml#maximum-provider-prices)
+- `Negotiation initialized` - proposals passing all the above limitations
+- `Negotiated successfully` - providers ready to deploy Ray on Golem image
+
+At the end of the output you can see the reasons of failing negotiations. 
+The most interesting are the reasons around providers' outbound settings, but for now we don't offer any actionable follow up.
+
+### Nodes availability
+
+The scanning ends with the successful negotiations - the `Negotiated successfully` line shows you the potential size of your cluster.
+Notice that the availability is dynamic - providers might be hired by someone else, more providers might become available, and also more providers might get discovered while your cluster is alive.
+
+The last thing is the image deployment. When starting the actual cluster (with `ray up`) the providers might also fail to start Ray on Golem image. This might decrease the maximum size of your cluster too.

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -102,7 +102,7 @@ ray_on_golem.client.exceptions.RayOnGolemClientError: Couldn't create node: {"er
 
 This means, that there are not enough providers on the network. 
 
-If you are running Ray on Golem on the testnet (property `network: "goerli"` in the cluster yaml) - most likely all the nodes are busy with requests of other users.
+If you are running Ray on Golem on the testnet (property `payment_network: "goerli"` in the cluster yaml) - most likely all the nodes are busy with requests of other users.
 
 We are preparing a tool to check providers' availability.
 Another solution would be to move to mainnet - we are also working on enabling this option.


### PR DESCRIPTION
In this PR:
- `total_budget` yaml property described in `Cluster yaml` article
- `per_cpu_budget` yaml section described in `Cluster yaml` article
- `Ray on Golem CLI` article