### PR TITLE
Ray troubleshooting after Previewer number 2

### DIFF
--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -125,7 +125,8 @@ The above shows the `ray-on-golem` webserver and the `yagna` daemon are running.
 
 Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again the nodes are found more quickly. 
 
-With that in mind, we recommend stopping only `ray-on-golem` and leaving `yagna` running. 
+With that in mind, when starting over we recommend stopping `ray-on-golem` and leaving `yagna` running 
+(but to get a truely clean slate you might want to stop `yagna` too). 
 
 The surest way to stop these services is to kill them (using the PID numbers as shown in the first column):
 ```bash

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Ray on Golem troubleshooting
-description: Comprehensive guide for resolving common Ray on Golem issues, including log file analysis and problem solving techniques.
+description: Comprehensive guide for resolving common Ray on Golem issues, including log file analysis and problem-solving techniques.
 pageTitle: Ray on Golem Troubleshooting Guide - Identify and Resolve Common Issues
 
 type: troubleshooting
@@ -21,7 +21,7 @@ Often you will find yourself wondering "How is my cluster doing?"
 
 Ray offers two tools to inspect the cluster state: the status and the dashboard.
 
-Ray status shows information about nodes constituting the cluster, the total resources of the cluster and their current usage.
+Ray status shows information about nodes constituting the cluster, the total resources of the cluster, and their current usage.
 
 The `ray status` command needs to be executed on the head node:
 ```bash
@@ -31,11 +31,11 @@ ray exec golem-cluster.yaml 'ray status'
 todo
 ```
 
-Ray dashboard visualises the nodes and what happens on them. 
+The Ray dashboard visualizes the nodes and what happens to them. 
 
 Run `ray dashboard golem-cluster.yaml` to forward your cluster's dashboard to [http://localhost:8265](http://localhost:8265).
 
-For an in debt description of the dashboard's amazing secrets check out the [Ray docs](https://docs.ray.io/en/latest/ray-observability/getting-started.html).
+For an in-debt description of the dashboard's amazing secrets check out the [Ray docs](https://docs.ray.io/en/latest/ray-observability/getting-started.html).
 
 {% /solution %}
 {% feedback identifier="what-is-going-on-with-my-cluster" /%}
@@ -54,7 +54,7 @@ it may not always be immediately obvious what the problem is from the output of 
 Where possible, we try to display a meaningful error message - e.g. when `ray up` fails to start up
 the Ray on Golem's webserver, we display a few last lines of the logs.
 
-If that's not enough to suggest a way to fix the issue, an investigation of logs may prove more useful. 
+If that's not enough to suggest a way to fix the issue investigating logs may prove more useful.
 
 {% solution %}
 
@@ -83,7 +83,7 @@ It may happen that something goes wrong and you wish to start over with a clean 
 
 {% solution %}
 
-The first thing to do is `ray down` - it should be enough to clear the situation, sadly it isn't always the case. 
+The first thing to do is `ray down` - it should be enough to clear the situation, but sadly it isn't always the case. 
 
 Let's first check if there are any orphaned components:
 ```bash
@@ -96,9 +96,9 @@ It produces an output like this:
   71258 ?        Sl     2:35 yagna
 ```
 
-The above shows `ray-on-golem` webserver and the `yagna` daemon are running.
+The above shows the `ray-on-golem` webserver and the `yagna` daemon are running.
 
-Note that Ray on Golem leaves `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you decide to start up your cluster again the nodes are found quicker. 
+Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again the nodes are found quicker. 
 
 With that in mind, we recommend killing only `ray-on-golem` and leaving `yagna` running. 
 

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -21,7 +21,7 @@ Often you will find yourself wondering "How is my cluster doing?"
 
 Ray offers two tools to inspect the cluster state: the status and the dashboard.
 
-Ray status shows information about nodes constituting the cluster, the total resources of the cluster, and their current usage.
+Ray status shows information about the nodes that make up the cluster, the total resources of the cluster, and their current usage.
 
 The `ray status` command needs to be executed on the head node:
 ```bash
@@ -123,7 +123,7 @@ It produces an output like this:
 
 The above shows the `ray-on-golem` webserver and the `yagna` daemon are running.
 
-Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again the nodes are found more quickly. 
+Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again, the nodes are found more quickly. 
 
 With that in mind, when starting over, we recommend stopping `ray-on-golem` and leaving `yagna` running 
 (but to get a truly clean slate you might want to stop `yagna` too). 
@@ -136,8 +136,6 @@ kill -9 71257 71258
 After it is done, the above command should show no more hanging processes:
 ```bash
 ps axc | grep -v grep | grep -E 'yagna|ray-on-golem'
-```
-```
 ```
 
 It might also be a good idea to clean up Ray's configuration cache files:

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -58,7 +58,7 @@ Shared connection to 192.168.0.3 closed.
 Ray dashboard visualizes the nodes and various other aspects of a running cluster, like specific jobs and function calls that get executed by each node.
 
 Run `ray dashboard golem-cluster.yaml` to forward your cluster's dashboard to [http://localhost:8265](http://localhost:8265).
-Keep it on to keep the tunnel active.
+Keep it running in the background so that the tunnel stays active as long as you need it.
 
 For an in-debt description of the dashboard's amazing secrets check out the [Ray docs](https://docs.ray.io/en/latest/ray-observability/getting-started.html).
 

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -79,7 +79,7 @@ it may not always be immediately obvious what the problem is from the output of 
 Where possible, we try to display a meaningful error message - e.g. when `ray up` fails to start up
 the Ray on Golem's webserver, we display a few last lines of the logs.
 
-If that's not enough to suggest a way to fix the issue investigating logs may prove more useful.
+If that's not enough to suggest a way to fix the issue, investigating the logs may provide the required details.
 
 {% solution %}
 

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -125,8 +125,8 @@ The above shows the `ray-on-golem` webserver and the `yagna` daemon are running.
 
 Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again the nodes are found more quickly. 
 
-With that in mind, when starting over we recommend stopping `ray-on-golem` and leaving `yagna` running 
-(but to get a truely clean slate you might want to stop `yagna` too). 
+With that in mind, when starting over, we recommend stopping `ray-on-golem` and leaving `yagna` running 
+(but to get a truly clean slate you might want to stop `yagna` too). 
 
 The surest way to stop these services is to kill them (using the PID numbers as shown in the first column):
 ```bash

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -277,7 +277,7 @@ This means, that you are trying to run a command that requires a cluster to be u
 The simplest reason might be that you hadn't successfully run `ray up`.
 Checkout [the logs](/docs/creators/ray/troubleshooting#ray-on-golem-s-log-files) to see what happened.
 
-Another explanation might be that the cluster was running, but it stopped - please share the logs with us to help us prevent this from happening in the future.
+Another explanation might be that the cluster had been launched, but it stopped or crashed - please share the logs with us to help us prevent this from happening in the future.
 
 If you see nothing interesting in the logs, you might want to [start over](/docs/creators/ray/troubleshooting#starting-over-with-a-clean-slate).
 

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -10,6 +10,35 @@ type: troubleshooting
 
 {% troubleshooting %}
 
+## What is going on with my cluster - status and dashboard 
+ 
+
+{% problem /%}
+
+Often you will find yourself wondering "How is my cluster doing?"
+
+{% solution %}
+
+Ray offers two tools to inspect the cluster state: the status and the dashboard.
+
+Ray status shows information about nodes constituting the cluster, the total resources of the cluster and their current usage.
+
+The `ray status` command needs to be executed on the head node:
+```bash
+ray exec golem-cluster.yaml 'ray status'
+```
+```
+todo
+```
+
+
+{% /solution %}
+{% feedback identifier="what-is-going-on-with-my-cluster" /%}
+{% /troubleshooting %}
+
+
+{% troubleshooting %}
+
 ## Ray on Golem's log files
  
 {% problem /%}
@@ -201,27 +230,6 @@ This informs Ray that everything after the double dash is not to be interpreted,
 {% /solution %}
 {% feedback identifier="ray-passing-arguments-to-your-ray-script-fails" /%}
 {% /troubleshooting %}
-
-
-<!--
-{% troubleshooting %}
-
-## Second `ray up` doesn't work 
- 
-
-{% problem /%}
-
-Description
-
-{% solution %}
-
-Solution
-
-{% /solution %}
-{% feedback identifier="ray-unique-tip-reference-for-feedback-gathering" /%}
-{% /troubleshooting %}
--->
-
 
 <!--
 {% troubleshooting %}

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -41,16 +41,17 @@ Given these, you can either:
 
 {% troubleshooting %}
 
-## Lack of a complete cleanup on shutdown
+## Starting over with a clean slate 
 
 {% problem /%}
 
-It may happen that some of Ray on Golem's components are still up after the successful completion of `ray down`.
-While it's usually not a problem in itself, you might wish to start with a clean slate on consecutive `ray up` runs.
+It may happen that something goes wrong and you might wish to start over with a clean slate. 
 
 {% solution %}
 
-To perform a cleanup, let's first check if there are any orphaned components indeed:
+The first thing to do is `ray down` - it should be enough to clear the situation, sadly it isn't always the case. 
+
+Let's first check if there are any orphaned components:
 ```bash
 ps axc | grep -v grep | grep -E 'yagna|ray-on-golem'
 ```
@@ -63,7 +64,10 @@ It produces an output like this:
 
 The above shows `ray-on-golem` webserver and the `yagna` daemon are running.
 
-The surest way to stop them is to kill them (using the PID numbers as shown in the first column):
+Note that Ray on Golem leaves `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you decide to start up your cluster again the nodes are found quicker. 
+With that in mind, we recommend killing only `ray-on-golem` and leaving `yagna` running. 
+
+The surest way to stop these services is to kill them (using the PID numbers as shown in the first column):
 ```bash
 kill -9 71257 71258
 ```

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -60,7 +60,7 @@ Ray dashboard visualizes the nodes and various other aspects of a running cluste
 Run `ray dashboard golem-cluster.yaml` to forward your cluster's dashboard to [http://localhost:8265](http://localhost:8265).
 Keep it running in the background so that the tunnel stays active as long as you need it.
 
-For an in-debt description of the dashboard's amazing secrets check out the [Ray docs](https://docs.ray.io/en/latest/ray-observability/getting-started.html).
+For a more thorough description of the dashboard's amazing secrets, check out the [Ray docs](https://docs.ray.io/en/latest/ray-observability/getting-started.html).
 
 {% /solution %}
 {% feedback identifier="what-is-going-on-with-my-cluster" /%}

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -28,12 +28,37 @@ The `ray status` command needs to be executed on the head node:
 ray exec golem-cluster.yaml 'ray status'
 ```
 ```
-todo
+Ray On Golem webserver
+  Not starting webserver, as it's already running
+Fetched IP: 192.168.0.3
+======== Autoscaler status: 2023-11-28 08:09:48.391906 ========
+Node status
+---------------------------------------------------------------
+Healthy:
+ 1 ray.head.default
+ 1 ray.worker.default
+Pending:
+ ray.worker.default, 5 launching
+Recent failures:
+ (no failures)
+
+Resources
+---------------------------------------------------------------
+Usage:
+ 2.0/2.0 CPU
+ 0B/5.34GiB memory
+ 0B/2.61GiB object_store_memory
+
+Demands:
+ {'CPU': 1.0}: 385+ pending tasks/actors
+Shared connection to 192.168.0.3 closed.
+
 ```
 
 The Ray dashboard visualizes the nodes and what happens to them. 
 
 Run `ray dashboard golem-cluster.yaml` to forward your cluster's dashboard to [http://localhost:8265](http://localhost:8265).
+Keep it on to keep the tunnel active.
 
 For an in-debt description of the dashboard's amazing secrets check out the [Ray docs](https://docs.ray.io/en/latest/ray-observability/getting-started.html).
 
@@ -235,6 +260,33 @@ This informs Ray that everything after the double dash is not to be interpreted,
 {% /solution %}
 {% feedback identifier="ray-passing-arguments-to-your-ray-script-fails" /%}
 {% /troubleshooting %}
+
+
+{% troubleshooting %}
+
+## Head node not found
+
+{% problem /%}
+
+Sometimes, you might get `RuntimeError: Head node of cluster (golem-cluster) not found!` error message when attempting to run a ray cli command.
+
+{% solution %}
+
+This means, that you are trying to run a command that requires a cluster to be up (like `ray submit`), but the cluster is not alive.
+
+The simplest reason might be that you didn't successfully run `ray up`.
+Checkout [the logs](/docs/creators/ray/troubleshooting#ray-on-golem-s-log-files) to see what happened.
+
+Another explanation might be that the cluster was running, but it stopped - please share the logs with us to help us prevent this from happening in the future.
+
+If you see nothing interesting in the logs, you might want to [start over](/docs/creators/ray/troubleshooting#starting-over-with-a-clean-slate).
+
+Feel free to reach out to us on [`#Ray on Golem` discord channel](https://chat.golem.network/) - we will be more than happy to assist.
+
+{% /solution %}
+{% feedback identifier="head-node-not-found" /%}
+{% /troubleshooting %}
+
 
 <!--
 {% troubleshooting %}

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -45,7 +45,7 @@ Given these, you can either:
 
 {% problem /%}
 
-It may happen that something goes wrong and you might wish to start over with a clean slate. 
+It may happen that something goes wrong and you wish to start over with a clean slate. 
 
 {% solution %}
 
@@ -65,6 +65,7 @@ It produces an output like this:
 The above shows `ray-on-golem` webserver and the `yagna` daemon are running.
 
 Note that Ray on Golem leaves `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you decide to start up your cluster again the nodes are found quicker. 
+
 With that in mind, we recommend killing only `ray-on-golem` and leaving `yagna` running. 
 
 The surest way to stop these services is to kill them (using the PID numbers as shown in the first column):

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -31,6 +31,11 @@ ray exec golem-cluster.yaml 'ray status'
 todo
 ```
 
+Ray dashboard visualises the nodes and what happens on them. 
+
+Run `ray dashboard golem-cluster.yaml` to forward your cluster's dashboard to [http://localhost:8265](http://localhost:8265).
+
+For an in debt description of the dashboard's amazing secrets check out the [Ray docs](https://docs.ray.io/en/latest/ray-observability/getting-started.html).
 
 {% /solution %}
 {% feedback identifier="what-is-going-on-with-my-cluster" /%}

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -125,7 +125,7 @@ The above shows the `ray-on-golem` webserver and the `yagna` daemon are running.
 
 Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again the nodes are found more quickly. 
 
-With that in mind, we recommend killing only `ray-on-golem` and leaving `yagna` running. 
+With that in mind, we recommend stopping only `ray-on-golem` and leaving `yagna` running. 
 
 The surest way to stop these services is to kill them (using the PID numbers as shown in the first column):
 ```bash

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -123,7 +123,7 @@ It produces an output like this:
 
 The above shows the `ray-on-golem` webserver and the `yagna` daemon are running.
 
-Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again the nodes are found quicker. 
+Note that Ray on Golem leaves the `yagna` daemon running on purpose - it stays connected to the Golem network maintaining current information about the providers so that when you start up your cluster again the nodes are found more quickly. 
 
 With that in mind, we recommend killing only `ray-on-golem` and leaving `yagna` running. 
 

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -274,7 +274,7 @@ Sometimes, you might get `RuntimeError: Head node of cluster (golem-cluster) not
 
 This means, that you are trying to run a command that requires a cluster to be up (like `ray submit`), but the cluster is not alive.
 
-The simplest reason might be that you didn't successfully run `ray up`.
+The simplest reason might be that you hadn't successfully run `ray up`.
 Checkout [the logs](/docs/creators/ray/troubleshooting#ray-on-golem-s-log-files) to see what happened.
 
 Another explanation might be that the cluster was running, but it stopped - please share the logs with us to help us prevent this from happening in the future.

--- a/src/pages/docs/creators/ray/troubleshooting.md
+++ b/src/pages/docs/creators/ray/troubleshooting.md
@@ -55,7 +55,7 @@ Shared connection to 192.168.0.3 closed.
 
 ```
 
-The Ray dashboard visualizes the nodes and what happens to them. 
+Ray dashboard visualizes the nodes and various other aspects of a running cluster, like specific jobs and function calls that get executed by each node.
 
 Run `ray dashboard golem-cluster.yaml` to forward your cluster's dashboard to [http://localhost:8265](http://localhost:8265).
 Keep it on to keep the tunnel active.


### PR DESCRIPTION
In this PR:
- pointers to status & dashboard in troubleshooting
- reformulation of restarting troubleshooting section
- `head node not found` troubleshooting section