### PR TITLE
get rid of deprecated methods in examples

### DIFF
--- a/src/markdoc/partials/docs/accessing-the-internet.md
+++ b/src/markdoc/partials/docs/accessing-the-internet.md
@@ -79,7 +79,7 @@ import { readFile } from 'fs/promises'
   } catch (err) {
     console.error('The task failed due to', err)
   } finally {
-    await executor.end()
+    await executor.shutdown()
   }
 })()
 ```
@@ -172,7 +172,7 @@ const url =
   } catch (err) {
     console.error('The task failed due to', err)
   } finally {
-    await executor.end()
+    await executor.shutdown()
   }
 })()
 ```

--- a/src/markdoc/partials/quickstarts/js-quickstart.md
+++ b/src/markdoc/partials/quickstarts/js-quickstart.md
@@ -102,7 +102,7 @@ Please note: This application requires Node.js version 18.0.0 or higher.
 
 Create a file named `requestor.mjs` and copy the following content into it. The code defines a task that runs the command `node -v` on the Golem Network and prints the result to your terminal.
 
-{% codefromgithub url="https://github.com/golemfactory/golem-js/blob/master/examples/docs-examples/quickstarts/quickstart/requestor.mjs" language="javascript" /%}
+{% codefromgithub url="https://raw.githubusercontent.com/golemfactory/golem-js/master/examples/docs-examples/quickstarts/quickstart/requestor.mjs" language="javascript" /%}
 
 {% alert level="info" %}
 

--- a/src/markdoc/partials/quickstarts/js-quickstart.md
+++ b/src/markdoc/partials/quickstarts/js-quickstart.md
@@ -102,7 +102,7 @@ Please note: This application requires Node.js version 18.0.0 or higher.
 
 Create a file named `requestor.mjs` and copy the following content into it. The code defines a task that runs the command `node -v` on the Golem Network and prints the result to your terminal.
 
-{% codefromgithub url="https://raw.githubusercontent.com/golemfactory/golem-js/7024c7041b92e84164f0f50c2fc7d948d60c7ff2/examples/docs-examples/quickstarts/quickstart/requestor.mjs" language="javascript" /%}
+{% codefromgithub url="https://github.com/golemfactory/golem-js/blob/master/examples/docs-examples/quickstarts/quickstart/requestor.mjs" language="javascript" /%}
 
 {% alert level="info" %}
 

--- a/src/pages/docs/creators/javascript/examples/accessing-internet.md
+++ b/src/pages/docs/creators/javascript/examples/accessing-internet.md
@@ -112,7 +112,7 @@ const url =
   } catch (err) {
     console.error('The task failed due to', err)
   } finally {
-    await executor.end()
+    await executor.shutdown()
   }
 })()
 ```

--- a/src/pages/docs/creators/javascript/tutorials/accessing-internet.md
+++ b/src/pages/docs/creators/javascript/tutorials/accessing-internet.md
@@ -86,7 +86,7 @@ import { readFile } from 'fs/promises'
   } catch (err) {
     console.error('The task failed due to', err)
   } finally {
-    await executor.end()
+    await executor.shutdown()
   }
 })()
 ```
@@ -181,7 +181,7 @@ const url =
   } catch (err) {
     console.error('The task failed due to', err)
   } finally {
-    await executor.end()
+    await executor.shutdown()
   }
 })()
 ```

--- a/src/pages/docs/creators/javascript/tutorials/quickstart-explained.md
+++ b/src/pages/docs/creators/javascript/tutorials/quickstart-explained.md
@@ -32,7 +32,6 @@ The basic structure of the script:
 
 ```js
 import { TaskExecutor } from '@golem-sdk/golem-js'
-
 ;(async () => {
   //... Function body in here
 })()
@@ -56,12 +55,17 @@ import { TaskExecutor } from '@golem-sdk/golem-js'
     yagnaOptions: { apiKey: 'try_golem' },
   })
 
-  // 2. Run the task
-  const taskResult =
-    await executor.run(/*taskToRunOnProvider to be provided here */)
-
-  // 3. Finish Task Executor
-  await executor.end()
+  try {
+    // 2. Run the task
+    const result =
+      await executor.run(/*taskToRunOnProvider to be provided here */)
+    console.log('Task result:', result)
+  } catch (err) {
+    console.error('An error occurred:', err)
+  } finally {
+    // 3. Finish Task Executor
+    await executor.shutdown()
+  }
 
   console.log('Task result:', taskResult)
 })()
@@ -77,18 +81,18 @@ const executor = await TaskExecutor.create({
 })
 ```
 
-Next (2) we run the task. Here we use a run method that accepts a task function as its argument. We will define the task function in a moment. We store the result of the `executor.run()` in taskResult variable.
+Next (2) we run the task. Here we use a run method that accepts a task function as its argument. We will define the task function in a moment. We store the result of the `executor.run()` in `result` variable.
 
 There are other methods that allow you to execute tasks. They are briefly presented in [Task API Guide](/docs/creators/javascript/guides/task-model#main-task-api-features) and explained in [examples](/docs/creators/javascript/examples) section.
 
 ```js
-const taskResult = await executor.run(taskToRunOnProvider)
+const result = await executor.run(taskToRunOnProvider)
 ```
 
 Finally (3) we gracefully finish task executor:
 
 ```js
-await executor.end()
+await executor.shutdown()
 ```
 
 ## Defining task function
@@ -110,7 +114,7 @@ const taskToRunOnProvider = async (ctx) => (await ctx.run('node -v')).stdout
 The output of the task function is passed to `executor.run()` and assigned to taskResult.
 Finally, we print it to the console.
 
-{% codefromgithub url="https://raw.githubusercontent.com/golemfactory/golem-js/7024c7041b92e84164f0f50c2fc7d948d60c7ff2/examples/docs-examples/tutorials/quickstart/index.mjs" language="javascript" /%}
+{% codefromgithub url="https://github.com/golemfactory/golem-js/blob/master/examples/docs-examples/quickstarts/quickstart/requestor.mjs" language="javascript" /%}
 
 ## Summary
 

--- a/src/pages/docs/creators/javascript/tutorials/quickstart-explained.md
+++ b/src/pages/docs/creators/javascript/tutorials/quickstart-explained.md
@@ -114,7 +114,7 @@ const taskToRunOnProvider = async (ctx) => (await ctx.run('node -v')).stdout
 The output of the task function is passed to `executor.run()` and assigned to taskResult.
 Finally, we print it to the console.
 
-{% codefromgithub url="https://github.com/golemfactory/golem-js/blob/master/examples/docs-examples/quickstarts/quickstart/requestor.mjs" language="javascript" /%}
+{% codefromgithub url="https://raw.githubusercontent.com/golemfactory/golem-js/master/examples/docs-examples/quickstarts/quickstart/requestor.mjs" language="javascript" /%}
 
 ## Summary
 

--- a/src/pages/docs/creators/javascript/tutorials/quickstart-explained.md
+++ b/src/pages/docs/creators/javascript/tutorials/quickstart-explained.md
@@ -81,7 +81,7 @@ const executor = await TaskExecutor.create({
 })
 ```
 
-Next (2) we run the task. Here we use a run method that accepts a task function as its argument. We will define the task function in a moment. We store the result of the `executor.run()` in `result` variable.
+Next (2) we run the task. Here we use a run method that accepts a task function as its argument. We will define the task function in a moment. We store the result of the `executor.run()` in the `result` variable.
 
 There are other methods that allow you to execute tasks. They are briefly presented in [Task API Guide](/docs/creators/javascript/guides/task-model#main-task-api-features) and explained in [examples](/docs/creators/javascript/examples) section.
 

--- a/src/pages/docs/creators/javascript/tutorials/running-in-browser.md
+++ b/src/pages/docs/creators/javascript/tutorials/running-in-browser.md
@@ -163,7 +163,7 @@ Note that the `create()` method received an additional 3 parameters:
         appendResults((await ctx.run("echo 'Hello World'")).stdout)
       )
       .catch((e) => logger.error(e))
-    await executor.end()
+    await executor.shutdown()
   }
   document.getElementById('echo').onclick = run
 </script>
@@ -218,7 +218,6 @@ The TaskExecutor offers an optional `logger` parameter. It will accept an object
     debug: (msg) => console.log(msg),
     error: (msg) => appendLog(`[${new Date().toISOString()}] [error] ${msg}`),
     info: (msg) => appendLog(`[${new Date().toISOString()}] [info] ${msg}`),
-    table: (msg) => appendLog(JSON.stringify(msg, null, '\t')),
   }
 
   //

--- a/src/pages/docs/creators/javascript/tutorials/running-parallel-tasks.md
+++ b/src/pages/docs/creators/javascript/tutorials/running-parallel-tasks.md
@@ -315,7 +315,7 @@ try {
 } catch (err) {
   console.log(`Password not found`)
 } finally {
-  await executor.end()
+  await executor.shutdown()
 }
 ```
 


### PR DESCRIPTION
for quickstart - updated link to use the code from repo
replaced code in places where example is in the docs (not imported from golem-js repo) [that was outbound examples that is not in the repo yet + snippets in tutorials
