### PR TITLE
Golem-Workers: json files instead of in-line curls

### DIFF
--- a/src/pages/docs/creators/golem-workers/hello-example.md
+++ b/src/pages/docs/creators/golem-workers/hello-example.md
@@ -153,6 +153,25 @@ which is a simple NGINX-based service that returns "Hello" on port **80**.
 - **Port Forwarding**: We forward port **80** on the node to **localhost:8080** on your machine,
 allowing you to access the service locally.
 
+## 3. Get the cluster's status
+
+Next, you should wait until your node is up.
+Check the cluster and node state with a call to `get-cluster`:
+
+```bash
+curl --location 'http://localhost:8000/get-cluster' \
+--header 'Content-Type: application/json' \
+--data @get-cluster.json
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/get-cluster.json)):
+```json
+{
+    "cluster_id": "example",
+}
+```
+
 ## 4. Access the Hello Service
 
 Once the node is **started**, open your browser and navigate to [http://localhost:8080](http://localhost:8080).

--- a/src/pages/docs/creators/golem-workers/hello-example.md
+++ b/src/pages/docs/creators/golem-workers/hello-example.md
@@ -163,7 +163,17 @@ You should see the message **Hello** displayed.
 After you're done, you should shut down the cluster using the following command:
 
 ```bash
-curl --location 'http://localhost:8000/delete-cluster' --header 'Content-Type: application/json' --data '{ "cluster_id": "example" }'
+curl --location 'http://localhost:8000/delete-cluster' \
+--header 'Content-Type: application/json' \
+--data @delete-cluster.json
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/delete-cluster.json)):
+```json
+{
+    "cluster_id": "example"
+}
 ```
 
 ---

--- a/src/pages/docs/creators/golem-workers/hello-example.md
+++ b/src/pages/docs/creators/golem-workers/hello-example.md
@@ -13,51 +13,70 @@ Unlike the **Stable Diffusion** example, this service does not require a GPU and
 It is designed as a basic introduction for new users, with more advanced examples like 
 the [Stable Diffusion tutorial](/docs/creators/golem-workers/sd-example) available for further exploration.
 
+## Prerequisites
+
+We will be using **`curl`** to interact with the Golem-Workers API, which runs on **localhost:8000** 
+(see [Getting started](/docs/creators/golem-workers/getting-started) if it is not).
+All API requests will use **JSON data** to configure and manage the Golem-Workers service.
+
+The JSON files used in this article can be found in the repository under the directory **`examples/hello-example`**. 
+Make sure you run the `curl` commands from within this repository to ensure the paths to the JSON files are correct.
+
+Feel free to experiment and modify the JSON files if you’d like to adjust configurations or explore different setups.
+
 ## 1. Create a Cluster
 
 To start, create a cluster with any name you choose (`cluster_id`). For this example, we'll use `example` as the `cluster_id`.
 
 ```bash
-curl --location 'http://localhost:8000/create-cluster' --header 'Content-Type: application/json' --data '{
-  "cluster_id": "example",
-  "budget_types": {
-    "default": {
-      "budget": {
-        "golem_workers.budgets.AveragePerCpuUsageLinearModelBudget": {
-          "average_cpu_load": 1,
-          "average_duration_hours": 0.5,
-          "average_max_cost": 1.5
+curl --location 'http://localhost:8000/create-cluster' \
+--header 'Content-Type: application/json' \
+--data @create-cluster.json 
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/create-cluster.json)):
+```json
+{
+    "cluster_id": "example",
+    "budget_types": {
+        "default": {
+            "budget": {
+                "golem_workers.budgets.AveragePerCpuUsageLinearModelBudget": {
+                    "average_cpu_load": 1,
+                    "average_duration_hours": 0.5,
+                    "average_max_cost": 1.5
+                }
+            },
+            "scope": "cluster"
         }
-      },
-      "scope": "cluster"
-    }
-  },
-  "network_types": {
-    "default": {
-      "ip": "192.168.0.1/16"
-    }
-  },
-  "node_types": {
-    "default": {
-      "market_config": {
-        "filters": [
-          {
-            "golem_reputation.ProviderBlacklistPlugin": {
-              "payment_network": "holesky"
+    },
+    "network_types": {
+        "default": {
+            "ip": "192.168.0.1/16"
+        }
+    },
+    "node_types": {
+        "default": {
+            "market_config": {
+                "filters": [
+                    {
+                        "golem_reputation.ProviderBlacklistPlugin": {
+                            "payment_network": "holesky"
+                        }
+                    }
+                ],
+                "sorters": [
+                    {
+                        "golem_reputation.ReputationScorer": {
+                            "payment_network": "holesky"
+                        }
+                    }
+                ]
             }
-          }
-        ],
-        "sorters": [
-          {
-            "golem_reputation.ReputationScorer": {
-              "payment_network": "holesky"
-            }
-          }
-        ]
-      }
+        }
     }
-  }
-}'
+}
 ```
 
 ### `create-cluster` JSON explained
@@ -74,48 +93,56 @@ Next, create a node using the **Hello Service** image from the Golem Registry.
 This service listens on port **80** and simply returns "Hello" when accessed.
 
 ```bash
-curl --location 'http://localhost:8000/create-node' --header 'Content-Type: application/json' --data '{
-  "cluster_id": "example",
-  "node_networks": {
-    "default": {}
-  },
-  "node_config": {
-    "market_config": {
-      "demand": {
-        "payloads": [
-          {
-            "golem_workers.payloads.ClusterNodePayload": {
-              "image_tag": "scalepointai/echo-test:2"
-            }
-          }
-        ]
-      }
+curl --location 'http://localhost:8000/create-node' \
+--header 'Content-Type: application/json' \
+--data @create-node.json
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/create-node.json)):
+```json
+{
+    "cluster_id": "example",
+    "node_networks": {
+        "default": {}
     },
-    "on_start_commands": [
-      {
-        "golem_workers.work.deploy_and_start_activity": {
-          "deploy_timeout_minutes": 60
-        }
-      },
-      {
-        "golem_workers.work.run_in_shell": [
-          [
-            "nginx"
-          ]
+    "node_config": {
+        "market_config": {
+            "demand": {
+                "payloads": [
+                    {
+                        "golem_workers.payloads.ClusterNodePayload": {
+                            "image_tag": "scalepointai/echo-test:2"
+                        }
+                    }
+                ]
+            }
+        },
+        "on_start_commands": [
+            {
+                "golem_workers.work.deploy_and_start_activity": {
+                    "deploy_timeout_minutes": 60
+                }
+            },
+            {
+                "golem_workers.work.run_in_shell": [
+                    [
+                        "nginx"
+                    ]
+                ]
+            }
+        ],
+        "sidecars": [
+            {
+                "golem_workers.sidecars.WebsocatPortTunnelSidecar": {
+                    "network_name": "default",
+                    "local_port": "8080",
+                    "remote_port": "80"
+                }
+            }
         ]
-      }
-    ],
-    "sidecars": [
-      {
-        "golem_workers.sidecars.WebsocatPortTunnelSidecar": {
-          "network_name": "default",
-          "local_port": "8080",
-          "remote_port": "80"
-        }
-      }
-    ]
-  }
-}'
+    }
+}
 ```
 
 ### `create-node` JSON explained
@@ -136,9 +163,7 @@ You should see the message **Hello** displayed.
 After you're done, you should shut down the cluster using the following command:
 
 ```bash
-curl --location 'http://localhost:8000/delete-cluster' --header 'Content-Type: application/json' --data '{
-  "cluster_id": "example"
-}'
+curl --location 'http://localhost:8000/delete-cluster' --header 'Content-Type: application/json' --data '{ "cluster_id": "example" }'
 ```
 
 ---

--- a/src/pages/docs/creators/golem-workers/hello-example.md
+++ b/src/pages/docs/creators/golem-workers/hello-example.md
@@ -8,7 +8,7 @@ type: Article
 
 # Golem-Workers Hello Service Example
 
-This example demonstrates how to run a simple "Hello" service using Golem Workers. 
+This example demonstrates how to run a simple "Hello" service using Golem-Workers. 
 Unlike the **Stable Diffusion** example, this service does not require a GPU and can be run for free on the **testnet**. 
 It is designed as a basic introduction for new users, with more advanced examples like 
 the [Stable Diffusion tutorial](/docs/creators/golem-workers/sd-example) available for further exploration.

--- a/src/pages/docs/creators/golem-workers/hello-example.md
+++ b/src/pages/docs/creators/golem-workers/hello-example.md
@@ -35,7 +35,7 @@ curl --location 'http://localhost:8000/create-cluster' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/create-cluster.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/create-cluster.json)):
 ```json
 {
     "cluster_id": "example",
@@ -99,7 +99,7 @@ curl --location 'http://localhost:8000/create-node' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/create-node.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/create-node.json)):
 ```json
 {
     "cluster_id": "example",
@@ -165,7 +165,7 @@ curl --location 'http://localhost:8000/get-cluster' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/get-cluster.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/get-cluster.json)):
 ```json
 {
     "cluster_id": "example",
@@ -188,7 +188,7 @@ curl --location 'http://localhost:8000/delete-cluster' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/delete-cluster.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/delete-cluster.json)):
 ```json
 {
     "cluster_id": "example"

--- a/src/pages/docs/creators/golem-workers/sd-example.md
+++ b/src/pages/docs/creators/golem-workers/sd-example.md
@@ -10,6 +10,8 @@ type: Article
 In this example, we’ll show you how to run a sample [Automatic1111](https://github.com/AUTOMATIC1111/stable-diffusion-webui) 
 (from [modelserve AI](https://modelserve.ai)) image using Golem Workers.
 
+## Prerequisites
+
 We will be using **`curl`** to interact with the Golem-Workers API, which runs on **localhost:8000** 
 (see [Getting started](/docs/creators/golem-workers/getting-started) if it is not).
 All API requests will use **JSON data** to configure and manage the Golem-Workers service.

--- a/src/pages/docs/creators/golem-workers/sd-example.md
+++ b/src/pages/docs/creators/golem-workers/sd-example.md
@@ -10,6 +10,15 @@ type: Article
 In this example, we’ll show you how to run a sample [Automatic1111](https://github.com/AUTOMATIC1111/stable-diffusion-webui) 
 (from [modelserve AI](https://modelserve.ai)) image using Golem Workers.
 
+We will be using **`curl`** to interact with the Golem-Workers API, which runs on **localhost:8000** 
+(see [Getting started](/docs/creators/golem-workers/getting-started) if it is not).
+All API requests will use **JSON data** to configure and manage the Golem-Workers service.
+
+The JSON files used in this article can be found in the repository under the directory **`examples/sd-example`**. 
+**Make sure** you run the `curl` commands from within this repository to ensure the paths to the JSON files are correct.
+
+Feel free to experiment and modify the JSON files if you’d like to adjust configurations or explore different setups.
+
 ## 1. Top up your account
 
 This article demonstrates how to rent a **mainnet GPU node**. 
@@ -37,49 +46,55 @@ In this step, create a cluster with any name you choose (`cluster_id`). For exam
 ```bash
 curl --location 'http://localhost:8000/create-cluster' \
 --header 'Content-Type: application/json' \
---data '{
-  "cluster_id": "example",
-  "payment_config": {
-    "network": "polygon"
-  },
-  "budget_types": {
-    "default": {
-      "budget": {
-        "golem_workers.budgets.AveragePerCpuUsageLinearModelBudget": {
-          "average_cpu_load": 1,
-          "average_duration_hours": 0.5,
-          "average_max_cost": 1.5
+--data @create-cluster.json 
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/create-cluster.json)):
+```json
+{
+    "cluster_id": "example",
+    "payment_config": {
+        "network": "polygon"
+    },
+    "budget_types": {
+        "default": {
+            "budget": {
+                "golem_workers.budgets.AveragePerCpuUsageLinearModelBudget": {
+                    "average_cpu_load": 1,
+                    "average_duration_hours": 0.5,
+                    "average_max_cost": 1.5
+                }
+            },
+            "scope": "cluster"
         }
-      },
-      "scope": "cluster"
-    }
-  },
-  "network_types": {
-    "default": {
-      "ip": "192.168.0.1/16"
-    }
-  },
-  "node_types": {
-    "default": {
-      "market_config": {
-        "filters": [
-          {
-            "golem_reputation.ProviderBlacklistPlugin": {
-              "payment_network": "polygon"
+    },
+    "network_types": {
+        "default": {
+            "ip": "192.168.0.1/16"
+        }
+    },
+    "node_types": {
+        "default": {
+            "market_config": {
+                "filters": [
+                    {
+                        "golem_reputation.ProviderBlacklistPlugin": {
+                            "payment_network": "polygon"
+                        }
+                    }
+                ],
+                "sorters": [
+                    {
+                        "golem_reputation.ReputationScorer": {
+                            "payment_network": "polygon"
+                        }
+                    }
+                ]
             }
-          }
-        ],
-        "sorters": [
-          {
-            "golem_reputation.ReputationScorer": {
-              "payment_network": "polygon"
-            }
-          }
-        ]
-      }
+        }
     }
-  }
-}'
+}
 ```
 
 ### `create-cluster` JSON explained
@@ -167,64 +182,68 @@ and specify the path to the model
 ```bash
 curl --location 'http://localhost:8000/create-node' \
 --header 'Content-Type: application/json' \
---data '{
-  "cluster_id": "example",
-  "node_networks": {
-	"default": {}
-  },
-  "node_config": {
-	"market_config": {
-  	  "demand": {
-    	"payloads": [
-      	  {
-            "golem_workers.payloads.ClusterNodePayload": {
-          	  "runtime": "vm-nvidia",
-          	  "image_tag": "scalepointai/automatic1111:4",
-          	  "subnet_tag": "gpu-test",
-                "outbound_urls": [
-                  "https://gpu-provider.dev.golem.network"
+--data @create-node.json 
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/create-node.json)):
+```json
+{
+    "cluster_id": "example",
+        "node_networks": {
+            "default": {}
+        },
+    "node_config": {
+        "market_config": {
+            "demand": {
+                "payloads": [
+                    {
+                        "golem_workers.payloads.ClusterNodePayload": {
+                            "runtime": "vm-nvidia",
+                            "image_tag": "scalepointai/automatic1111:4",
+                            "outbound_urls": [
+                                "https://gpu-provider.dev.golem.network"
+                            ]
+                        }
+                    }
                 ]
             }
-      	  }
-    	]
-  	  }
-	},
-	"on_start_commands": [
-  	  {
-    	"golem_workers.work.deploy_and_start_activity": {
-      	  "deploy_timeout_minutes": 60
-    	}
-  	  },
-  	  {
-    	"golem_workers.work.prepare_and_run_ssh_server": {
-          "ssh_private_key_path": "/tmp/ssh_key"
-    	}
-  	  },
-  	  {
-    	"golem_workers.work.run_in_shell": [
-      	  "cd /usr/src/app/ && ./start.sh --model_url https://gpu-provider.dev.golem.network/models/v1-5-pruned-emaonly.safetensors > /usr/src/app/output/log 2>&1 &"
-    	]
-  	  }
-	],
-	"sidecars": [
-  	  {
-    	"golem_workers.sidecars.WebsocatPortTunnelSidecar": {
-      	  "network_name": "default",
-      	  "local_port": "8080",
-      	  "remote_port": "8000"
-        }
-  	  },
-  	  {
-    	"golem_workers.sidecars.WebsocatPortTunnelSidecar": {
-      	  "network_name": "default",
-      	  "local_port": "8081",
-      	  "remote_port": "8001"
-    	}
-  	  }
-	]
-  }
-}'
-```
+        },
+        "on_start_commands": [
+            {
+                "golem_workers.work.deploy_and_start_activity": {
+                    "deploy_timeout_minutes": 60
+                }
+            },
+            {
+                "golem_workers.work.prepare_and_run_ssh_server": {
+                    "ssh_private_key_path": "/tmp/ssh_key"
+                }
+            },
+            {
+                "golem_workers.work.run_in_shell": [
+                    "cd /usr/src/app/ && ./start.sh --model_url https://gpu-provider.dev.golem.network/models/v1-5-pruned-emaonly.safetensors > /usr/src/app/output/log 2>&1 &"
+                ]
+            }
+        ],
+        "sidecars": [
+            {
+                "golem_workers.sidecars.WebsocatPortTunnelSidecar": {
+                    "network_name": "default",
+                    "local_port": "8080",
+                    "remote_port": "8000"
+                }
+            },
+            {
+                "golem_workers.sidecars.WebsocatPortTunnelSidecar": {
+                    "network_name": "default",
+                    "local_port": "8081",
+                    "remote_port": "8001"
+                }
+            }
+        ]
+    }
+}
 
 ### `create-node` JSON explained
 
@@ -322,8 +341,6 @@ In this example, we forward two ports to allow access to services running on the
 - `localhost:8080`: This is where the **Automatic1111 Web UI** will be visible, allowing users to interact with the model interface.
 - `localhost:8081`: This is a maintenance port, providing a bit of insight into the state of the node and its health.
 
-
-
 ## 4. Get the node's status
 
 Next, you should wait until your node is up.
@@ -332,10 +349,16 @@ Check the node state with a call to `get-node`:
 ```bash
 curl --location 'http://localhost:8000/get-node' \
 --header 'Content-Type: application/json' \
---data '{
-  "cluster_id": "example",
-  "node_id": "node0"
-}'
+--data @get-node.json
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/get-node.json)):
+```json
+{
+    "cluster_id": "example",
+    "node_id": "node0"
+}
 ```
 
 It returns the node’s state:
@@ -360,7 +383,9 @@ To generate some images using the Automatic1111 GUI, you can either enter your p
 
 #### Alternatively, use the automatic1111 API directly 
 
-Copy and run the following Python code (directly in the terminal or using a Jupyter Notebook)
+Copy and run the following Python code (directly in the terminal or using a Jupyter Notebook). 
+The code is also availabla on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/sd-inference.py).
 
 ```python
 import requests, time, io, base64
@@ -402,8 +427,14 @@ After completing the testing, you can shut down the cluster, using the following
 ```bash
 curl --location 'http://localhost:8000/delete-cluster' \
 --header 'Content-Type: application/json' \
---data '{
-  "cluster_id": "example"
-}'
+--data @delete-cluster.json 
+```
+
+This is the json file you have just used (also available on 
+[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/delete-cluster.json)):
+```json
+{
+    "cluster_id": "example"
+}
 ```
 

--- a/src/pages/docs/creators/golem-workers/sd-example.md
+++ b/src/pages/docs/creators/golem-workers/sd-example.md
@@ -8,7 +8,7 @@ type: Article
 # Stable diffusion usage example
 
 In this example, we’ll show you how to run a sample [Automatic1111](https://github.com/AUTOMATIC1111/stable-diffusion-webui) 
-(from [modelserve AI](https://modelserve.ai)) image using Golem Workers.
+(from [modelserve AI](https://modelserve.ai)) image using Golem-Workers.
 
 ## Prerequisites
 

--- a/src/pages/docs/creators/golem-workers/sd-example.md
+++ b/src/pages/docs/creators/golem-workers/sd-example.md
@@ -52,7 +52,7 @@ curl --location 'http://localhost:8000/create-cluster' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/create-cluster.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/create-cluster.json)):
 ```json
 {
     "cluster_id": "example",
@@ -188,7 +188,7 @@ curl --location 'http://localhost:8000/create-node' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/create-node.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/create-node.json)):
 ```json
 {
     "cluster_id": "example",
@@ -355,7 +355,7 @@ curl --location 'http://localhost:8000/get-node' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/get-node.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/get-node.json)):
 ```json
 {
     "cluster_id": "example",
@@ -387,7 +387,7 @@ To generate some images using the Automatic1111 GUI, you can either enter your p
 
 Copy and run the following Python code (directly in the terminal or using a Jupyter Notebook). 
 The code is also availabla on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/sd-inference.py).
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/sd-example/sd-inference.py).
 
 ```python
 import requests, time, io, base64
@@ -433,7 +433,7 @@ curl --location 'http://localhost:8000/delete-cluster' \
 ```
 
 This is the json file you have just used (also available on 
-[github](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/delete-cluster.json)):
+[GitHub](https://github.com/golemfactory/golem-workers/raw/main/examples/hello-example/delete-cluster.json)):
 ```json
 {
     "cluster_id": "example"


### PR DESCRIPTION
In this PR:
- [x] changed code snippets in hello and sd examples to use files taken from golem-workers repo instead of inline jsons
- [x] added missing get-cluster section in hello example