### PR TITLE
docs(providers): note Docker on Windows is unsupported

### DIFF
--- a/src/pages/docs/creators/tools/yagna/restoring-golem-wallet.md
+++ b/src/pages/docs/creators/tools/yagna/restoring-golem-wallet.md
@@ -17,7 +17,7 @@ curl -sSf https://join.golem.network/as-requestor | bash -
 
 {% alert level="warning" %}
 
-The above line assumes you're a requestor on a Unix-like platform (Linux or Mac). If that's not the case, you should use an installation procedure appropriate for your platform. Please refer to the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors) or the [analogous instructions for providers](/docs/providers/provider-installation).
+The above line assumes you're a requestor on Linux or macOS. On Windows, use the installation procedure for your platform instead, as described in the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors). If you're restoring a provider's wallet, note that providers are supported on Linux only - see the [provider installation guide](/docs/providers/provider-installation).
 
 {% /alert %}
 

--- a/src/pages/docs/creators/tools/yagna/restoring-golem-wallet.md
+++ b/src/pages/docs/creators/tools/yagna/restoring-golem-wallet.md
@@ -17,7 +17,7 @@ curl -sSf https://join.golem.network/as-requestor | bash -
 
 {% alert level="warning" %}
 
-The above line assumes you're a requestor on Linux or macOS. On Windows, use the installation procedure for your platform instead, as described in the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors). If you're restoring a provider's wallet, note that providers are supported on Linux only - see the [provider installation guide](/docs/providers/provider-installation).
+This command assumes a requestor on Linux or macOS. On Windows, follow the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors) instead. To restore a provider's wallet, note that providers run on x86-64 Linux only - see the [provider installation guide](/docs/providers/provider-installation).
 
 {% /alert %}
 

--- a/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
+++ b/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
@@ -16,9 +16,7 @@ In this article, we'll show you how to install and configure Yagna in case you w
 Yagna is a service that will let you communicate with the Golem Network and perform operations on it. Let's install it.
 
 {% alert level="warning" %}
-Linux is the only supported platform for requestors. Yagna may work on other systems, such as macOS or Windows, and instructions for them are provided below, but those setups are not supported and we do not provide support for problems with deployments running on them.
-
-If you work on macOS or Windows, you can run yagna on an x86-64 Linux virtual machine or cloud instance and connect to it from your machine. That generally works fine, but it is not officially supported either.
+Linux is the only supported platform for requestors. The macOS and Windows instructions below usually work, but we do not support those setups. If you work on either, run yagna on an x86-64 Linux VM or cloud instance and connect to it from your machine.
 {% /alert %}
 
 #### Install Yagna

--- a/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
+++ b/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
@@ -18,7 +18,7 @@ Yagna is a service that will let you communicate with the Golem Network and perf
 {% alert level="warning" %}
 Linux is the only supported platform for requestors. Yagna may work on other systems, such as macOS or Windows, and instructions for them are provided below, but those setups are not supported and we do not provide support for problems with deployments running on them.
 
-If you work on macOS or Windows, you can run yagna in a Linux virtual machine or on a Linux cloud instance. That generally works fine, but it is not officially supported either.
+If you work on macOS or Windows, you can run yagna on an x86-64 Linux virtual machine or cloud instance and connect to it from your machine. That generally works fine, but it is not officially supported either.
 {% /alert %}
 
 #### Install Yagna

--- a/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
+++ b/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
@@ -15,6 +15,10 @@ In this article, we'll show you how to install and configure Yagna in case you w
 
 Yagna is a service that will let you communicate with the Golem Network and perform operations on it. Let's install it.
 
+{% alert level="warning" %}
+Linux is the only supported platform for requestors. Yagna may work on other systems, such as macOS or Windows, and instructions for them are provided below, but those setups are not supported and we do not provide support for problems with deployments running on them.
+{% /alert %}
+
 #### Install Yagna
 
 {% tabs %}

--- a/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
+++ b/src/pages/docs/creators/tools/yagna/yagna-installation-for-requestors.md
@@ -17,6 +17,8 @@ Yagna is a service that will let you communicate with the Golem Network and perf
 
 {% alert level="warning" %}
 Linux is the only supported platform for requestors. Yagna may work on other systems, such as macOS or Windows, and instructions for them are provided below, but those setups are not supported and we do not provide support for problems with deployments running on them.
+
+If you work on macOS or Windows, you can run yagna in a Linux virtual machine or on a Linux cloud instance. That generally works fine, but it is not officially supported either.
 {% /alert %}
 
 #### Install Yagna

--- a/src/pages/docs/providers/provider-faq.md
+++ b/src/pages/docs/providers/provider-faq.md
@@ -73,6 +73,8 @@ There's no strict requirements for running a provider node except for the follow
 - A linux machine with the x86-64 architecture
 - Nested virtulization enabled in the BIOS
 
+Linux is the only supported platform. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments.
+
 ### Does Golem automatically remove task data?
 
 Yes, by default, Golem clears task data after 30 days. You can alter this setting using the command `ya-provider clean –help`.

--- a/src/pages/docs/providers/provider-faq.md
+++ b/src/pages/docs/providers/provider-faq.md
@@ -73,7 +73,7 @@ There's no strict requirements for running a provider node except for the follow
 - A linux machine with the x86-64 architecture
 - Nested virtulization enabled in the BIOS
 
-Linux is the only supported platform. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments.
+Linux is the only supported platform. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments. A Linux virtual machine with nested virtualization enabled, so that `/dev/kvm` is available inside it, generally works fine, but that setup is not officially supported either.
 
 ### Does Golem automatically remove task data?
 

--- a/src/pages/docs/providers/provider-faq.md
+++ b/src/pages/docs/providers/provider-faq.md
@@ -70,10 +70,10 @@ The requestor has the flexibility to select providers based on any set of criter
 
 There's no strict requirements for running a provider node except for the following:
 
-- A linux machine with the x86-64 architecture
+- A linux machine with the x86-64 architecture - ARM is not used as a provider architecture for now
 - Nested virtulization enabled in the BIOS
 
-Linux is the only supported platform. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments. On an x86-64 host you can run the provider in a Linux virtual machine with nested virtualization enabled, so that `/dev/kvm` is available inside it - that generally works fine, but is not officially supported either. On a Mac it is not an option, as Apple Silicon can only run ARM64 guests while the provider requires x86-64 with KVM.
+x86-64 Linux is the only supported platform. ARM machines, including Apple Silicon and ARM servers, cannot run a provider at all - there is no ARM build for now. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments. On an x86-64 host you can run the provider in a Linux virtual machine with nested virtualization enabled, so that `/dev/kvm` is available inside it - that generally works fine, but is not officially supported either. On a Mac it is not an option, as Apple Silicon can only run ARM64 guests while the provider requires x86-64 with KVM.
 
 ### Does Golem automatically remove task data?
 

--- a/src/pages/docs/providers/provider-faq.md
+++ b/src/pages/docs/providers/provider-faq.md
@@ -73,7 +73,7 @@ There's no strict requirements for running a provider node except for the follow
 - A linux machine with the x86-64 architecture
 - Nested virtulization enabled in the BIOS
 
-Linux is the only supported platform. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments. A Linux virtual machine with nested virtualization enabled, so that `/dev/kvm` is available inside it, generally works fine, but that setup is not officially supported either.
+Linux is the only supported platform. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments. On an x86-64 host you can run the provider in a Linux virtual machine with nested virtualization enabled, so that `/dev/kvm` is available inside it - that generally works fine, but is not officially supported either. On a Mac it is not an option, as Apple Silicon can only run ARM64 guests while the provider requires x86-64 with KVM.
 
 ### Does Golem automatically remove task data?
 

--- a/src/pages/docs/providers/provider-faq.md
+++ b/src/pages/docs/providers/provider-faq.md
@@ -70,10 +70,10 @@ The requestor has the flexibility to select providers based on any set of criter
 
 There's no strict requirements for running a provider node except for the following:
 
-- A linux machine with the x86-64 architecture - ARM is not used as a provider architecture for now
+- A linux machine with the x86-64 architecture - ARM is not supported for now
 - Nested virtulization enabled in the BIOS
 
-x86-64 Linux is the only supported platform. ARM machines, including Apple Silicon and ARM servers, cannot run a provider at all - there is no ARM build for now. macOS is not supported, and Windows is not supported either - running the provider in Docker Desktop for Windows may work, but we do not provide support for such deployments. On an x86-64 host you can run the provider in a Linux virtual machine with nested virtualization enabled, so that `/dev/kvm` is available inside it - that generally works fine, but is not officially supported either. On a Mac it is not an option, as Apple Silicon can only run ARM64 guests while the provider requires x86-64 with KVM.
+x86-64 Linux is the only supported platform. ARM machines - Apple Silicon and ARM servers alike - cannot run a provider for now, and macOS is not supported on any hardware. Docker Desktop for Windows, or a Linux VM with nested virtualization on an x86-64 host, will usually work, but we do not support either.
 
 ### Does Golem automatically remove task data?
 

--- a/src/pages/docs/providers/provider-installation.md
+++ b/src/pages/docs/providers/provider-installation.md
@@ -29,7 +29,7 @@ The provider runs its tasks inside virtual machines, so the container needs acce
 {% alert level="warning" %}
 Linux is the only supported platform for running a provider. macOS is not supported at all, on Docker or otherwise. Running the provider on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
 
-If you are on macOS or Windows, run the provider inside a Linux virtual machine with nested virtualization enabled instead. That setup generally works fine, but it is not officially supported either.
+On Windows you can instead run the provider inside a Linux virtual machine with nested virtualization enabled. That generally works fine, but it is not officially supported either. On macOS this is not an option: Apple Silicon machines can only run ARM64 guests, while the provider requires x86-64 with KVM. Use a separate Linux machine or a Linux server with KVM access instead.
 {% /alert %}
 
 ### Choosing the image version

--- a/src/pages/docs/providers/provider-installation.md
+++ b/src/pages/docs/providers/provider-installation.md
@@ -18,7 +18,7 @@ If you prefer to install the software directly on your system, see [installing d
 
 To follow this tutorial, you will need the following:
 
-- A linux machine with the x86-64 architecture
+- A linux machine with the x86-64 architecture - ARM machines, including Apple Silicon and ARM servers, cannot be used as providers for now
 - Nested virtualization enabled in your BIOS, so that the host exposes the `/dev/kvm` device
 - [Docker Engine](https://docs.docker.com/engine/install/) with the [Compose plugin](https://docs.docker.com/compose/install/)
 
@@ -27,7 +27,7 @@ The provider runs its tasks inside virtual machines, so the container needs acce
 {% /alert %}
 
 {% alert level="warning" %}
-Linux is the only supported platform for running a provider. macOS is not supported at all, on Docker or otherwise. Running the provider on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
+x86-64 Linux is the only supported platform for running a provider. ARM is not supported at all - there is no ARM provider build for now, so an ARM machine cannot run a provider on any operating system. macOS is not supported either, on Docker or otherwise. Running the provider on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
 
 On Windows you can instead run the provider inside a Linux virtual machine with nested virtualization enabled. That generally works fine, but it is not officially supported either. On macOS this is not an option: Apple Silicon machines can only run ARM64 guests, while the provider requires x86-64 with KVM. Use a separate Linux machine or a Linux server with KVM access instead.
 {% /alert %}

--- a/src/pages/docs/providers/provider-installation.md
+++ b/src/pages/docs/providers/provider-installation.md
@@ -27,7 +27,7 @@ The provider runs its tasks inside virtual machines, so the container needs acce
 {% /alert %}
 
 {% alert level="warning" %}
-Linux is the only supported platform for running the provider in Docker. Running it on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
+Linux is the only supported platform for running a provider. macOS is not supported at all, on Docker or otherwise. Running the provider on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
 {% /alert %}
 
 ### Choosing the image version

--- a/src/pages/docs/providers/provider-installation.md
+++ b/src/pages/docs/providers/provider-installation.md
@@ -18,7 +18,7 @@ If you prefer to install the software directly on your system, see [installing d
 
 To follow this tutorial, you will need the following:
 
-- A linux machine with the x86-64 architecture - ARM machines, including Apple Silicon and ARM servers, cannot be used as providers for now
+- A linux machine with the x86-64 architecture - ARM is not supported for now
 - Nested virtualization enabled in your BIOS, so that the host exposes the `/dev/kvm` device
 - [Docker Engine](https://docs.docker.com/engine/install/) with the [Compose plugin](https://docs.docker.com/compose/install/)
 
@@ -27,9 +27,9 @@ The provider runs its tasks inside virtual machines, so the container needs acce
 {% /alert %}
 
 {% alert level="warning" %}
-x86-64 Linux is the only supported platform for running a provider. ARM is not supported at all - there is no ARM provider build for now, so an ARM machine cannot run a provider on any operating system. macOS is not supported either, on Docker or otherwise. Running the provider on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
+x86-64 Linux is the only supported platform. ARM machines - Apple Silicon and ARM servers alike - cannot run a provider for now, and macOS is not supported on any hardware.
 
-On Windows you can instead run the provider inside a Linux virtual machine with nested virtualization enabled. That generally works fine, but it is not officially supported either. On macOS this is not an option: Apple Silicon machines can only run ARM64 guests, while the provider requires x86-64 with KVM. Use a separate Linux machine or a Linux server with KVM access instead.
+Docker Desktop for Windows (including WSL 2), or a Linux VM with nested virtualization on an x86-64 host, will usually work. Neither is supported, and we do not help with problems on those setups.
 {% /alert %}
 
 ### Choosing the image version

--- a/src/pages/docs/providers/provider-installation.md
+++ b/src/pages/docs/providers/provider-installation.md
@@ -28,6 +28,8 @@ The provider runs its tasks inside virtual machines, so the container needs acce
 
 {% alert level="warning" %}
 Linux is the only supported platform for running a provider. macOS is not supported at all, on Docker or otherwise. Running the provider on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
+
+If you are on macOS or Windows, run the provider inside a Linux virtual machine with nested virtualization enabled instead. That setup generally works fine, but it is not officially supported either.
 {% /alert %}
 
 ### Choosing the image version

--- a/src/pages/docs/providers/provider-installation.md
+++ b/src/pages/docs/providers/provider-installation.md
@@ -26,6 +26,10 @@ To follow this tutorial, you will need the following:
 The provider runs its tasks inside virtual machines, so the container needs access to the host's KVM module. This means your Docker host has to be a physical machine, or a virtual machine with nested virtualization enabled. Check that `/dev/kvm` exists on the host before you start.
 {% /alert %}
 
+{% alert level="warning" %}
+Linux is the only supported platform for running the provider in Docker. Running it on Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running on Docker on Windows.
+{% /alert %}
+
 ### Choosing the image version
 
 Always run the most recent stable release of the provider image. You can find the available tags on [Docker Hub](https://hub.docker.com/r/golemfactory/provider/tags), and the accompanying release notes on the [yagna releases page](https://github.com/golemfactory/yagna/releases).

--- a/src/pages/docs/providers/wallet/restoration.md
+++ b/src/pages/docs/providers/wallet/restoration.md
@@ -16,7 +16,7 @@ curl -sSf https://join.golem.network/as-provider | bash -
 
 {% alert level="warning" %}
 
-The above line assumes you're a requestor on a Unix-like platform (Linux or Mac). If that's not the case, you should use an installation procedure appropriate for your platform. Please refer to the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors) or the [analogous instructions for providers](/docs/providers/provider-installation).
+The above line installs the provider bundle, and requires Linux. Providers are supported on Linux only - see the [provider installation guide](/docs/providers/provider-installation). If you're restoring a requestor's wallet, install yagna with the procedure for your platform instead, as described in the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors).
 
 {% /alert %}
 

--- a/src/pages/docs/providers/wallet/restoration.md
+++ b/src/pages/docs/providers/wallet/restoration.md
@@ -16,7 +16,7 @@ curl -sSf https://join.golem.network/as-provider | bash -
 
 {% alert level="warning" %}
 
-The above line installs the provider bundle, and requires Linux. Providers are supported on Linux only - see the [provider installation guide](/docs/providers/provider-installation). If you're restoring a requestor's wallet, install yagna with the procedure for your platform instead, as described in the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors).
+This command installs the provider bundle and requires x86-64 Linux - see the [provider installation guide](/docs/providers/provider-installation). To restore a requestor's wallet, install yagna as described in the [Yagna installation instructions for requestors](/docs/creators/tools/yagna/yagna-installation-for-requestors).
 
 {% /alert %}
 


### PR DESCRIPTION
Adds a warning to the provider installation prerequisites: Linux is the only supported platform for running the provider in Docker. Docker Desktop for Windows (including the WSL 2 backend) may work, but it is not a supported setup and we do not provide support for problems with deployments running there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bA95fWqDhGRJWFAvooqJw